### PR TITLE
Sanitize dependencies

### DIFF
--- a/config/templates/upstart/ovs-scheduled-tasks.conf
+++ b/config/templates/upstart/ovs-scheduled-tasks.conf
@@ -12,4 +12,4 @@ setuid ovs
 setgid ovs
 
 chdir /opt/OpenvStorage
-exec /usr/local/bin/celery beat -A ovs.celery_run -l info -S ovs.celery_beat.DistributedScheduler
+exec /usr/bin/celery beat -A ovs.celery_run -l info -S ovs.celery_beat.DistributedScheduler

--- a/config/templates/upstart/ovs-workers.conf
+++ b/config/templates/upstart/ovs-workers.conf
@@ -12,4 +12,4 @@ setuid ovs
 setgid ovs
 
 chdir /opt/OpenvStorage
-exec /usr/local/bin/celery worker -A ovs.celery_run -l info -Q ovs_generic,ovs_<WORKER_QUEUE> --autoscale=8,2 -Ofair
+exec /usr/bin/celery worker -A ovs.celery_run -l info -Q ovs_generic,ovs_<WORKER_QUEUE> --autoscale=8,2 -Ofair

--- a/ovs/lib/setup.py
+++ b/ovs/lib/setup.py
@@ -1424,16 +1424,16 @@ EOF
                         storagedriver_config.save()
 
     @staticmethod
-    def _logstash_installed():
-        if os.path.exists('/usr/sbin/logstash') \
-           or os.path.exists('/usr/bin/logstash') \
-           or os.path.exists('/opt/logstash/bin/logstash'):
+    def _logstash_installed(client):
+        if client.file_exists('/usr/sbin/logstash') \
+           or client.file_exists('/usr/bin/logstash') \
+           or client.file_exists('/opt/logstash/bin/logstash'):
             return True
         return False
 
     @staticmethod
     def _configure_logstash(client, cluster_name):
-        if not SetupController._logstash_installed():
+        if not SetupController._logstash_installed(client):
             logger.debug("Logstash is not installed, skipping it's configuration")
             return False
 
@@ -1494,7 +1494,7 @@ EOF
     def _finalize_setup(client, node_name, node_type, hypervisor_info, unique_id):
         cluster_ip = client.ip
         client.dir_create('/opt/OpenvStorage/webapps/frontend/logging')
-        if SetupController._logstash_installed():
+        if SetupController._logstash_installed(client):
             SetupController._change_service_state(client, 'logstash', 'restart')
         SetupController._replace_param_in_config(client=client,
                                                  config_file='/opt/OpenvStorage/webapps/frontend/logging/config.js',

--- a/ovs/lib/setup.py
+++ b/ovs/lib/setup.py
@@ -1340,11 +1340,11 @@ EOF
             try:
                 client.run('service rabbitmq-server stop')
                 if ovs_rabbitmq_running is True:
-                    ServiceManager.stop_service('ovs-rabbitmq', client) 
+                    ServiceManager.stop_service('ovs-rabbitmq', client)
             except subprocess.CalledProcessError:
                 print('  Failure stopping the rabbitmq process')
         else:
-            ServiceManager.stop_service('ovs-rabbitmq', client) 
+            ServiceManager.stop_service('ovs-rabbitmq', client)
 
         client.run('rabbitmq-server -detached 2> /dev/null; sleep 5;')
 
@@ -1424,7 +1424,19 @@ EOF
                         storagedriver_config.save()
 
     @staticmethod
+    def _logstash_installed():
+        if os.path.exists('/usr/sbin/logstash') \
+           or os.path.exists('/usr/bin/logstash') \
+           or os.path.exists('/opt/logstash/bin/logstash'):
+            return True
+        return False
+
+    @staticmethod
     def _configure_logstash(client, cluster_name):
+        if not SetupController._logstash_installed():
+            logger.debug("Logstash is not installed, skipping it's configuration")
+            return False
+
         print 'Configuring logstash'
         logger.info('Configuring logstash')
         SetupController._replace_param_in_config(client=client,
@@ -1482,7 +1494,8 @@ EOF
     def _finalize_setup(client, node_name, node_type, hypervisor_info, unique_id):
         cluster_ip = client.ip
         client.dir_create('/opt/OpenvStorage/webapps/frontend/logging')
-        SetupController._change_service_state(client, 'logstash', 'restart')
+        if SetupController._logstash_installed():
+            SetupController._change_service_state(client, 'logstash', 'restart')
         SetupController._replace_param_in_config(client=client,
                                                  config_file='/opt/OpenvStorage/webapps/frontend/logging/config.js',
                                                  old_value='http://"+window.location.hostname+":9200',
@@ -1768,7 +1781,7 @@ EOF
             client.dir_create(mp)
             if mp not in output:
                 client.run('mount {0}'.format(mp))
-   
+
         client.run('chmod 1777 /var/tmp')
 
     @staticmethod

--- a/packaging/debian/debian/control
+++ b/packaging/debian/debian/control
@@ -8,18 +8,22 @@ Build-Depends: python (>= 2.7.2)
 Package: openvstorage-core
 Architecture: amd64
 Pre-Depends: python (>= 2.7.2), python-pip (>= 1.4.1-2)
-Depends: rabbitmq-server (<< 3.5), python-memcache (>= 1.47-2), memcached (>= 1.4.7),
+Depends: rabbitmq-server (>= 3.2.4), python-memcache (>= 1.47-2), memcached (>= 1.4.7),
  volumedriver-server (>= 3.6.0), arakoon (>= 1.8), alba (>=0.5), lsscsi (>= 0.27-2), libvirt0 (>= 1.1.1),
- python-libvirt (>= 1.1.1), virtinst (>= 0.600.4), python-dev (>= 2.7.5), python-pyinotify,
- libev4 (>= 1:4.11-1), logstash (>= 1.4.0-1-c82dc09), autossh, avahi-utils (>= 0.6.31),
- python-boto, nfs-kernel-server, ipython, gcc, openvpn, devscripts
+ python-libvirt (>= 1.1.1), python-dev (>= 2.7.5), python-pyinotify, sudo,
+ libev4 (>= 1:4.11-1), python-boto, nfs-kernel-server,
+ ipython, gcc, devscripts, openssh-server, python-paramiko,
+ python-pysnmp, python-kombu (>= 3.0.7), python-celery (>= 3.1.6), python-pika,
+ python-six, python-protobuf, python-pyudev
+Recommends: avahi-utils (>= 0.6.31), openvpn, ntp
+Suggests: logstash (>= 1.4.0-1-c82dc09), virtinst (>= 0.600.4)
 Description: openvStorage core
  Core components for the Open vStorage product
 
 Package: openvstorage-webapps
 Architecture: amd64
 Pre-Depends: openvstorage-core (= ${binary:Version})
-Depends: python-django (>= 1.5.1-2), nginx (>= 1.2.6),
+Depends: python-django (>= 1.5.1-2), nginx (>= 1.2.6), python-djangorestframework (>= 2.3.9),
  gunicorn (>= 0.15.0-1), python-gevent (>= 0.13.0-1build2), python-markdown (>= 2.3.1-1)
 Description: openvStorage Web Applications
  Web components for the Open vStorage product

--- a/packaging/debian/debian/control
+++ b/packaging/debian/debian/control
@@ -11,8 +11,8 @@ Pre-Depends: python (>= 2.7.2), python-pip (>= 1.4.1-2)
 Depends: rabbitmq-server (>= 3.2.4), python-memcache (>= 1.47-2), memcached (>= 1.4.7),
  volumedriver-server (>= 3.6.0), arakoon (>= 1.8), alba (>=0.5), lsscsi (>= 0.27-2), libvirt0 (>= 1.1.1),
  python-libvirt (>= 1.1.1), python-dev (>= 2.7.5), python-pyinotify, sudo,
- libev4 (>= 1:4.11-1), python-boto, nfs-kernel-server,
- ipython, gcc, devscripts, openssh-server, python-paramiko,
+ libev4 (>= 1:4.11-1), python-boto, nfs-kernel-server, python-suds-jurko, python-datadiff,
+ ipython, gcc, devscripts, openssh-server, python-paramiko, python-rpyc,
  python-pysnmp4, python-kombu (>= 3.0.7), python-celery (>= 3.1.6), python-pika,
  python-six, python-protobuf, python-pyudev
 Recommends: avahi-utils (>= 0.6.31), openvpn, ntp

--- a/packaging/debian/debian/control
+++ b/packaging/debian/debian/control
@@ -3,7 +3,7 @@ Maintainer: Kenneth Henderick <kenneth.henderick@openvstorage.com>
 Standards-Version: 3.9.4.0
 Section: python
 Priority: optional
-Build-Depends: python (>= 2.7.2)
+Build-Depends: python-all (>= 2.7.2), debhelper (>= 9)
 
 Package: openvstorage-core
 Architecture: amd64
@@ -13,7 +13,7 @@ Depends: rabbitmq-server (>= 3.2.4), python-memcache (>= 1.47-2), memcached (>= 
  python-libvirt (>= 1.1.1), python-dev (>= 2.7.5), python-pyinotify, sudo,
  libev4 (>= 1:4.11-1), python-boto, nfs-kernel-server,
  ipython, gcc, devscripts, openssh-server, python-paramiko,
- python-pysnmp, python-kombu (>= 3.0.7), python-celery (>= 3.1.6), python-pika,
+ python-pysnmp4, python-kombu (>= 3.0.7), python-celery (>= 3.1.6), python-pika,
  python-six, python-protobuf, python-pyudev
 Recommends: avahi-utils (>= 0.6.31), openvpn, ntp
 Suggests: logstash (>= 1.4.0-1-c82dc09), virtinst (>= 0.600.4)

--- a/packaging/debian/debian/openvstorage-core.postinst
+++ b/packaging/debian/debian/openvstorage-core.postinst
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-# Post install deps
-pip install paramiko
-pip install pysnmp==4.2.5
-
 python /opt/OpenvStorage/scripts/install/openvstorage-core.postinst.py "__NEW_VERSION__" "$@"

--- a/packaging/debian/debian/openvstorage-core.preinst
+++ b/packaging/debian/debian/openvstorage-core.preinst
@@ -6,13 +6,7 @@ then
     echo -e '\n\nPlease start upgrade through GUI because all nodes in the cluster need to be upgraded simultaneously!!!!!\n\n'
     exit 1
 else
-    pip install kombu==3.0.26
-    pip install celery==3.1.6
     pip install suds-jurko==0.5
-    pip install pika
-    pip install six --upgrade
-    pip install protobuf
-    pip install pyudev
     pip install datadiff
     pip install rpyc
 

--- a/packaging/debian/debian/openvstorage-core.preinst
+++ b/packaging/debian/debian/openvstorage-core.preinst
@@ -6,10 +6,6 @@ then
     echo -e '\n\nPlease start upgrade through GUI because all nodes in the cluster need to be upgraded simultaneously!!!!!\n\n'
     exit 1
 else
-    pip install suds-jurko==0.5
-    pip install datadiff
-    pip install rpyc
-
     if [ ! -f /etc/openvstorage_id ]
     then
         echo `openssl rand -base64 64 | tr -dc A-Z-a-z-0-9 | head -c 16` > /etc/openvstorage_id

--- a/packaging/debian/debian/openvstorage-webapps.preinst
+++ b/packaging/debian/debian/openvstorage-webapps.preinst
@@ -4,7 +4,4 @@ if [[ ! -z "$2" && ! -f /etc/ready_for_upgrade ]]
 then
     echo -e '\n\nPlease start upgrade through GUI because all nodes in the cluster need to be upgraded simultaneously!!!!!\n\n'
     exit 1
-else
-    pip install djangorestframework==2.3.9
-    pip install markdown
 fi

--- a/scripts/install/openvstorage-core.postinst.py
+++ b/scripts/install/openvstorage-core.postinst.py
@@ -15,6 +15,7 @@
 
 import os
 import re
+import pwd
 from subprocess import check_output
 
 SECRET_KEY_LENGTH = 50
@@ -53,10 +54,18 @@ for service_name in ('rabbitmq-server', 'memcached'):
 check_output('chown -R ovs:ovs /opt/OpenvStorage', shell=True)
 check_output('find /opt/OpenvStorage -name *.pyc -exec rm -rf {} \;', shell=True)
 
-# Few logstash cleanups
-check_output('usermod -a -G adm logstash', shell=True)
-if os.path.exists('/etc/init/logstash-web.conf'):
-    check_output('echo manual > /etc/init/logstash-web.override', shell=True)
+# Few logstash cleanups if it's installed
+try:
+    pwd.getpwnam('logstash')
+    logstash_installed = True
+except KeyError:
+    logstash_installed = False
+
+if logstash_installed:
+    # TODO: logstash user should be added into adm group by logstash package
+    check_output('usermod -a -G adm logstash', shell=True)
+    if os.path.exists('/etc/init/logstash-web.conf'):
+        check_output('echo manual > /etc/init/logstash-web.override', shell=True)
 
 # Configure logging
 check_output('chmod 755 /opt/OpenvStorage/scripts/system/rotate-storagedriver-logs.sh', shell=True)


### PR DESCRIPTION
- logstash and virtinst packages are suggested but not installed automatically as dependency
- make openvpn and avahi-utils as suggested packages only so they are installed automatically but it can be overriden
- add missing dependencies (openssh-server, sudo)
- install available python modules with packages instead of pip
- require rabbitmq-server newer or same as in ubuntu trusty
