### PR TITLE
OVS-2663: Use default MaxRead/MaxWrite buffer size values

### DIFF
--- a/config/templates/ganesha-export.conf
+++ b/config/templates/ganesha-export.conf
@@ -53,10 +53,10 @@ EXPORT
   # can be overridden with the following export settings :
 
   # Maximum size for a read operation.
-  MaxRead = 524288;
+  # MaxRead = 4194304;
 
   # Maximum size for a write operation.
-  MaxWrite = 524288;
+  # MaxWrite = 4194304;
 
   # Prefered size for a read operation.
   #PrefRead = 16384;


### PR DESCRIPTION
VMWare client seems to ask more than the MaxRead/MaxWrite values
we are already using.
This should not happen of course because the client has already taken
the values at mount time (FSINFO) and so is completely aware of the
server maximum read/write size.
Use the default values which are large enough and seem to solve
the problem.

Signed-off-by: Chrysostomos Nanakos cnanakos@openvstorage.com
