### PR TITLE
OVS-3651 - Increased timeout for ensure single decorator in CHAINED mode

### DIFF
--- a/ovs/lib/helpers/exceptions.py
+++ b/ovs/lib/helpers/exceptions.py
@@ -1,0 +1,20 @@
+# Copyright 2015 iNuron NV
+#
+# Licensed under the Open vStorage Modified Apache License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.openvstorage.org/license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class EnsureSingleTimeoutReached(Exception):
+    """
+    Exception thrown when a celery.task with the ensure_single decorator could not be started in due time
+    """
+    pass

--- a/ovs/lib/storagerouter.py
+++ b/ovs/lib/storagerouter.py
@@ -837,7 +837,7 @@ class StorageRouterController(object):
         vpool.size = vfs_info.f_blocks * vfs_info.f_bsize
         vpool.save()
 
-        VDiskController.dtl_checkup(vpool_guid=vpool.guid)
+        VDiskController.dtl_checkup(vpool_guid=vpool.guid, chain_timeout=600)
         for vdisk in vpool.vdisks:
             MDSServiceController.ensure_safety(vdisk=vdisk)
 


### PR DESCRIPTION
Introduced new exception EnsureSingleTimeoutReached
Implemented new exception in certain usecases and/or increased timeout in certain DTL checkup calls
