### PR TITLE
fix 'ovs setup' bailing out if avahi is not installed

### DIFF
--- a/ovs/lib/setup.py
+++ b/ovs/lib/setup.py
@@ -1645,7 +1645,7 @@ EOF
 
     @staticmethod
     def _avahi_installed(client):
-        installed = client.run('which avahi-daemon')
+        installed = client.run('which avahi-daemon || :')
         if installed == '':
             logger.debug('Avahi not installed')
             return False


### PR DESCRIPTION
If avahi is not installed, 'which avahi-daemon' returns with exit code 1 resulting in "ovs setup" bailing out...
