### PR TITLE
Compute nodes are using the localhost rabbitmq instead of the cluster.

### DIFF
--- a/ovs/extensions/generic/heartbeat.py
+++ b/ovs/extensions/generic/heartbeat.py
@@ -45,10 +45,12 @@ class HeartBeat(object):
 
         current_time = int(time.time())
         machine_id = System.get_my_machine_id()
-        amqp = '{0}://{1}:{2}@{3}//'.format(EtcdConfiguration.get('/ovs/framework/messagequeue|protocol'),
-                                            EtcdConfiguration.get('/ovs/framework/messagequeue|user'),
-                                            EtcdConfiguration.get('/ovs/framework/messagequeue|password'),
-                                            EtcdConfiguration.get('/ovs/framework/hosts/{0}/ip'.format(machine_id)))
+        rmq_servers = EtcdConfiguration.get('/ovs/framework/messagequeue|endpoints')
+        amqp = ';'.join(['{0}://{1}:{2}@{3}//'.format(EtcdConfiguration.get('/ovs/framework/messagequeue|protocol'),
+                                                      EtcdConfiguration.get('/ovs/framework/messagequeue|user'),
+                                                      EtcdConfiguration.get('/ovs/framework/messagequeue|password'),
+                                                      server)
+                         for server in rmq_servers])
 
         with Celery(broker=amqp) as celery:
             worker_states = celery.control.inspect().ping()

--- a/ovs/extensions/generic/heartbeat.py
+++ b/ovs/extensions/generic/heartbeat.py
@@ -18,8 +18,8 @@ import time
 from ovs.dal.exceptions import ConcurrencyException
 from ovs.dal.hybrids.storagerouter import StorageRouter
 from ovs.dal.lists.storagerouterlist import StorageRouterList
-from ovs.lib.storagerouter import StorageRouterController
 from ovs.extensions.generic.system import System
+from ovs.lib.storagerouter import StorageRouterController
 from ovs.log.log_handler import LogHandler
 from subprocess import check_output, CalledProcessError
 

--- a/ovs/extensions/generic/heartbeat.py
+++ b/ovs/extensions/generic/heartbeat.py
@@ -47,14 +47,14 @@ class HeartBeat(object):
         current_time = int(time.time())
 
         routers = StorageRouterList.get_storagerouters()
-        for n in routers:
-            node = StorageRouter(n.guid, datastore_wins=None)
+        for node in routers:
             if node.machine_id == machine_id:
                 for _ in xrange(2):
-                    node_save = StorageRouter(n.guid, datastore_wins=None)
+                    node_save = StorageRouter(node.guid, datastore_wins=None)
                     node_save.heartbeats['process'] = current_time
                     try:
                         node_save.save()
+                        break
                     except ConcurrencyException as ex:
                         logger.warning('Failed to save {0}. {1}'.format(node.name, ex))
                 StorageRouterController.ping.s(node.guid, current_time).apply_async(routing_key='sr.{0}'.format(machine_id))

--- a/ovs/lib/storagerouter.py
+++ b/ovs/lib/storagerouter.py
@@ -88,12 +88,13 @@ class StorageRouterController(object):
     def ping(storagerouter_guid, timestamp):
         for _ in xrange(2):
             storagerouter = StorageRouter(storagerouter_guid, datastore_wins=None)
-            storagerouter.heartbeats['celery'] = timestamp
+            if timestamp > storagerouter.heartbeats['celery']:
+                storagerouter.heartbeats['celery'] = timestamp
             try:
                 storagerouter.save()
                 break
             except ConcurrencyException as ex:
-                pass
+                StorageRouterController._logger.warning('Failed to save {0}. {1}'.format(storagerouter.name, ex))
 
         return storagerouter_guid, timestamp
 

--- a/ovs/lib/storagerouter.py
+++ b/ovs/lib/storagerouter.py
@@ -92,13 +92,9 @@ class StorageRouterController(object):
                 storagerouter.heartbeats['celery'] = timestamp
                 try:
                     storagerouter.save()
-                    break
+                    return
                 except ConcurrencyException as ex:
                     StorageRouterController._logger.warning('Failed to save {0}. {1}'.format(storagerouter.name, ex))
-            else:
-                break
-
-        return storagerouter_guid, timestamp
 
     @staticmethod
     @celery.task(name='ovs.storagerouter.get_metadata')

--- a/ovs/lib/storagerouter.py
+++ b/ovs/lib/storagerouter.py
@@ -90,11 +90,13 @@ class StorageRouterController(object):
             storagerouter = StorageRouter(storagerouter_guid, datastore_wins=None)
             if timestamp > storagerouter.heartbeats['celery']:
                 storagerouter.heartbeats['celery'] = timestamp
-            try:
-                storagerouter.save()
+                try:
+                    storagerouter.save()
+                    break
+                except ConcurrencyException as ex:
+                    StorageRouterController._logger.warning('Failed to save {0}. {1}'.format(storagerouter.name, ex))
+            else:
                 break
-            except ConcurrencyException as ex:
-                StorageRouterController._logger.warning('Failed to save {0}. {1}'.format(storagerouter.name, ex))
 
         return storagerouter_guid, timestamp
 

--- a/ovs/lib/storagerouter.py
+++ b/ovs/lib/storagerouter.py
@@ -83,6 +83,13 @@ class StorageRouterController(object):
     storagerouterclient.Logger.enableLogging()
 
     @staticmethod
+    @celery.task(name='ovs.storagerouter.ping')
+    def ping(storagerouter_guid, timestamp):
+        storagerouter = StorageRouter(storagerouter_guid)
+        storagerouter.heartbeats['celery'] = timestamp
+        storagerouter.save()
+
+    @staticmethod
     @celery.task(name='ovs.storagerouter.get_metadata')
     def get_metadata(storagerouter_guid):
         """


### PR DESCRIPTION
Fixed this issue by using the /ovs/framework/messagequeue/endpoints.
Code based on ovs/celery_run.py.
@khenderick could you please do a code review of this?
Did you already test the multi-node string?
Should i make a ticket to get all the rabbitmq ips in the endpoints field?

```
etcdctl get /ovs/framework/messagequeue
{"endpoints": ["10.100.199.1:5672"], "protocol": "amqp", "queues": {"storagedriver": "volumerouter"}, "user": "", "password": "", "metadata": {"internal": true}}
```
