### PR TITLE
A couple of small fixes to get snapshot rollback working

### DIFF
--- a/webapps/api/backend/views/vdisks.py
+++ b/webapps/api/backend/views/vdisks.py
@@ -85,7 +85,7 @@ class VDiskViewSet(viewsets.ViewSet):
         :param timestamp: Timestamp of the snapshot to rollback to
         """
         return VDiskController.rollback.delay(vdisk_guid=vdisk.guid,
-                                              timestamp=timestamp)
+                                              timestamp=str(timestamp))
 
     @action()
     @required_roles(['read', 'write', 'manage'])

--- a/webapps/frontend/locales/en-US/ovs.json
+++ b/webapps/frontend/locales/en-US/ovs.json
@@ -871,9 +871,9 @@
                 "nosnapshots": "No Snapshots found",
                 "snapshot": "Snapshots",
                 "rollbackstarted": "Rollback started",
-                "inprogressvdisk": "Disk __what__ rollback in progress...",
-                "failedvdisk": "Disk __what__ rollback failed.",
-                "successvdisk": "Disk __what__ rollback successfully."
+                "inprogress": "Disk __what__ rollback in progress...",
+                "failed": "Disk __what__ rollback failed.",
+                "success": "Disk __what__ rollback successfully."
             }
         },
         "clone": {


### PR DESCRIPTION
After some digging in the framework source code I discovered that getting snapshot rollback working is only a couple of small changes.

This will spare us a lot of useless temporary engineering work until ovs engineers can provide a fix for rollback that is geo-scale compatible. (see https://github.com/openvstorage/framework/issues/896)
