### PR TITLE
Revert "Make sure only a single vPool can be added at a time"

### DIFF
--- a/ovs/lib/storagerouter.py
+++ b/ovs/lib/storagerouter.py
@@ -191,7 +191,6 @@ class StorageRouterController(object):
 
     @staticmethod
     @celery.task(name='ovs.storagerouter.add_vpool')
-    @ensure_single(task_name='ovs.storagerouter.add_vpool', mode='CHAINED')
     def add_vpool(parameters):
         """
         Add a vPool to the machine this task is running on


### PR DESCRIPTION
Reverts openvstorage/framework#1034

After some more discussions with @kinvaris, it turns out that for setups the code is often run in parallel, so we'd better just check up the code to remove possible race conditions.
