### PR TITLE
fix #1084

### DIFF
--- a/scripts/system/ovs
+++ b/scripts/system/ovs
@@ -103,7 +103,7 @@ elif [ "$1" = "monitor" ] ; then
         service_manager=`cat /proc/1/comm`
         if test "$service_manager" = "systemd"
         then
-            watch -n 1 'echo "OVS running processes:";echo; systemctl -l | grep ovs- | grep "loaded active" | sort; echo; echo "OVS non-running processes:"; systemctl -a | grep ovs- | grep "loaded inactive" | sort; echo; echo "OVS disabled services:"; systemctl list-unit-files | grep ovs- | grep disabled | sort'
+            watch -n 1 'echo "OVS running processes:";echo; systemctl -l | grep ovs- | grep "loaded active" | sort; echo; echo "OVS non-running processes:"; systemctl -a | grep ovs- | grep "dead\|activating\|inactive" | sort; echo; echo "OVS disabled services:"; systemctl list-unit-files | grep ovs- | grep disabled | sort'
         else
             watch -n 1 'echo "\nOVS running processes:\n";initctl list | grep ovs | grep start/running | sort;echo "\nOVS non-running processes:\n";initctl list | grep ovs | grep -v start/running | sort'
         fi


### PR DESCRIPTION
output: 

```
OVS non-running processes:
ovs-openstack-events-consumer.service                                                                                                                                 not-found inactive dead      ovs-openstack-events-consumer.ser
vice
ovs-volumedriver_myvpool.service                                                                                                                                      loaded    inactive dead      ovs volumedriver

```
