### PR TITLE
Remotes with single ip as list now returns the object

### DIFF
--- a/ovs/extensions/generic/remote.py
+++ b/ovs/extensions/generic/remote.py
@@ -41,8 +41,10 @@ class remote(object):
         Initializes the context
         """
         self.ips = []
+        self.single_ip = False
         if isinstance(ip_info, basestring):
             self.ips = [ip_info]
+            self.single_ip = True
         elif isinstance(ip_info, list):
             self.ips = ip_info
         else:
@@ -74,7 +76,7 @@ class remote(object):
             self.connections = self.ips
         else:
             self.connections = [server.classic_connect() for server in self.servers]
-        if len(self.connections) == 1:
+        if len(self.connections) == 1 and self.single_ip is True:
             return self._build_remote_module(self.connections[0])
         return self
 

--- a/ovs/extensions/generic/remote.py
+++ b/ovs/extensions/generic/remote.py
@@ -76,7 +76,7 @@ class remote(object):
             self.connections = self.ips
         else:
             self.connections = [server.classic_connect() for server in self.servers]
-        if len(self.connections) == 1 and self.direct_mode is True:
+        if self.direct_mode is True:
             return self._build_remote_module(self.connections[0])
         return self
 

--- a/ovs/extensions/generic/remote.py
+++ b/ovs/extensions/generic/remote.py
@@ -41,10 +41,10 @@ class remote(object):
         Initializes the context
         """
         self.ips = []
-        self.single_ip = False
+        self.direct_mode = False
         if isinstance(ip_info, basestring):
             self.ips = [ip_info]
-            self.single_ip = True
+            self.direct_mode = True
         elif isinstance(ip_info, list):
             self.ips = ip_info
         else:
@@ -76,7 +76,7 @@ class remote(object):
             self.connections = self.ips
         else:
             self.connections = [server.classic_connect() for server in self.servers]
-        if len(self.connections) == 1 and self.single_ip is True:
+        if len(self.connections) == 1 and self.direct_mode is True:
             return self._build_remote_module(self.connections[0])
         return self
 


### PR DESCRIPTION
The object has __getitem()__ and will be used as 
```
remote([ip]) as remotes:
 remotes[ip] <--- returns connection
```
Instead of
```
remote[ip] as remotes:
remotes. <--- already the connection
```

remote("ip") remains unchanged