### PR TITLE
#1351 - Mark halted volumes in the GUI

### DIFF
--- a/ovs/extensions/storageserver/storagedriver.py
+++ b/ovs/extensions/storageserver/storagedriver.py
@@ -33,7 +33,7 @@ from volumedriver.storagerouter import storagerouterclient
 from volumedriver.storagerouter.storagerouterclient import \
     ClusterContact, ClusterNodeConfig, \
     DTLConfig, DTLConfigMode, DTLMode, Logger, \
-    MDSMetaDataBackendConfig,  MDSNodeConfig, \
+    MaxRedirectsExceededException, MDSMetaDataBackendConfig,  MDSNodeConfig, \
     ObjectNotFoundException as SRCObjectNotFoundException, \
     ReadCacheBehaviour, ReadCacheMode, \
     Role, Statistics, VolumeInfo

--- a/ovs/extensions/storageserver/tests/mockups.py
+++ b/ovs/extensions/storageserver/tests/mockups.py
@@ -202,6 +202,7 @@ class StorageRouterClient(object):
         _ = self, req_timeout_secs
         return type('Info', (), {'cluster_multiplier': 0,
                                  'lba_size': 0,
+                                 'halted': False,
                                  'metadata_backend_config': property(lambda s: None),
                                  'object_type': property(lambda s: 'BASE'),
                                  'vrouter_id': property(lambda s: None)})()
@@ -266,6 +267,7 @@ class StorageRouterClient(object):
         _ = req_timeout_secs
         return type('Info', (), {'cluster_multiplier': property(lambda s: 8),
                                  'lba_size': property(lambda s: 512),
+                                 'halted': property(lambda s: False),
                                  'metadata_backend_config': property(lambda s: StorageRouterClient._metadata_backend_config[self.vpool_guid].get(volume_id)),
                                  'object_type': property(lambda s: StorageRouterClient.object_type[self.vpool_guid].get(volume_id, 'BASE')),
                                  'vrouter_id': property(lambda s: StorageRouterClient.vrouter_id[self.vpool_guid].get(volume_id))})()

--- a/ovs/lib/storagerouter.py
+++ b/ovs/lib/storagerouter.py
@@ -863,20 +863,18 @@ class StorageRouterController(object):
         vpool.status = VPool.STATUSES.RUNNING
         vpool.save()
         vpool.invalidate_dynamics(['configuration'])
-        if offline_nodes_detected is True:
-            try:
-                VDiskController.dtl_checkup(vpool_guid=vpool.guid, ensure_single_timeout=600)
-            except:
-                pass
-            try:
-                for vdisk in vpool.vdisks:
-                    MDSServiceController.ensure_safety(vdisk=vdisk)
-            except:
-                pass
-        else:
+
+        # When a node is offline, we can run into errors, but also when 1 or more volumes are not running
+        # Scheduled tasks below, so don't really care whether they succeed or not
+        try:
             VDiskController.dtl_checkup(vpool_guid=vpool.guid, ensure_single_timeout=600)
-            for vdisk in vpool.vdisks:
+        except:
+            pass
+        for vdisk in vpool.vdisks:
+            try:
                 MDSServiceController.ensure_safety(vdisk=vdisk)
+            except:
+                pass
         StorageRouterController._logger.info('Add vPool {0} ended successfully'.format(vpool_name))
 
     @staticmethod

--- a/webapps/api/backend/views/vdisks.py
+++ b/webapps/api/backend/views/vdisks.py
@@ -55,6 +55,8 @@ class VDiskViewSet(viewsets.ViewSet):
         :type storagerouterguid: str
         :param query: A query to be executed if required
         :type query: DataQuery
+        :return: List of vDisks matching the parameters specified
+        :rtype: list[ovs.dal.hybrids.vdisk.VDisk]
         """
         if vpoolguid is not None:
             vpool = VPool(vpoolguid)
@@ -79,6 +81,8 @@ class VDiskViewSet(viewsets.ViewSet):
         Load information about a given vDisk
         :param vdisk: Guid of the virtual disk to retrieve
         :type vdisk: VDisk
+        :return: The vDisk based on the guid provided
+        :rtype: ovs.dal.hybrids.vdisk.VDisk
         """
         return vdisk
 
@@ -94,9 +98,28 @@ class VDiskViewSet(viewsets.ViewSet):
         :type vdisk: VDisk
         :param timestamp: Timestamp of the snapshot to rollback to
         :type timestamp: int
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         return VDiskController.rollback.delay(vdisk_guid=vdisk.guid,
                                               timestamp=str(timestamp))
+
+    @action()
+    @log()
+    @required_roles(['read', 'write', 'manage'])
+    @return_task()
+    @load(VDisk)
+    def restart(self, vdisk, force=False):
+        """
+        Restart a vDisk
+        :param vdisk: Guid of the virtual disk
+        :type vdisk: ovs.dal.hybrids.vdisk.VDisk
+        :param force: Force a restart at a possible cost of data loss
+        :type force: bool
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
+        """
+        return VDiskController.restart.delay(vdisk_guid=vdisk.guid, force=force)
 
     @action()
     @required_roles(['read', 'write', 'manage'])
@@ -111,6 +134,8 @@ class VDiskViewSet(viewsets.ViewSet):
         :type new_config_params: dict
         :param version: Client version
         :type version: int
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         if version == 1 and 'dtl_target' in new_config_params:
             storage_router = StorageRouterList.get_by_ip(new_config_params['dtl_target'])
@@ -135,7 +160,7 @@ class VDiskViewSet(viewsets.ViewSet):
         :param vdisk: Vdisk to get the children from
         :type vdisk: VDisk
         :return: Guids of the child vDisks
-        :rtype: list
+        :rtype: list[str]
         """
         return vdisk.child_vdisks_guids
 
@@ -148,6 +173,8 @@ class VDiskViewSet(viewsets.ViewSet):
         Retrieve the configuration parameters for the given disk from the storagedriver.
         :param vdisk: Guid of the virtual disk to retrieve its running configuration
         :type vdisk: VDisk
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         return VDiskController.get_config_params.delay(vdisk_guid=vdisk.guid)
 
@@ -169,6 +196,8 @@ class VDiskViewSet(viewsets.ViewSet):
         :type snapshot_id: str
         :param pagecache_ratio: Ratio (0 < x <= 1) of the pagecache size related to the size
         :type pagecache_ratio: float
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         return VDiskController.clone.delay(vdisk_guid=vdisk.guid,
                                            snapshot_id=snapshot_id,
@@ -190,6 +219,8 @@ class VDiskViewSet(viewsets.ViewSet):
         :type target_storagerouter_guid: str
         :param force: Indicate whether to force the migration (forcing the migration might cause data loss)
         :type force: bool
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         return VDiskController.move.delay(vdisk_guid=vdisk.guid,
                                           target_storagerouter_guid=target_storagerouter_guid,
@@ -207,6 +238,8 @@ class VDiskViewSet(viewsets.ViewSet):
         :type vdisk: VDisk
         :param snapshot_id: ID of the snapshot to remove
         :type snapshot_id: str
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         return VDiskController.delete_snapshot.delay(vdisk_guid=vdisk.guid,
                                                      snapshot_id=snapshot_id)
@@ -221,6 +254,8 @@ class VDiskViewSet(viewsets.ViewSet):
         Sets a vDisk as template
         :param vdisk: Guid of the virtual disk to set as template
         :type vdisk: VDisk
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         if len(vdisk.child_vdisks) > 0:
             raise HttpNotAcceptableException(error_description='vDisk has clones',
@@ -245,6 +280,8 @@ class VDiskViewSet(viewsets.ViewSet):
         :type storagerouter_guid: str
         :param pagecache_ratio: Ratio (0 < x <= 1) of the pagecache size related to the size
         :type pagecache_ratio: float
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         storagerouter = StorageRouter(storagerouter_guid)
         for storagedriver in storagerouter.storagedrivers:
@@ -278,6 +315,8 @@ class VDiskViewSet(viewsets.ViewSet):
         :type automatic: bool
         :param sticky: Indicates whether the system should clean the snapshot automatically
         :type sticky: bool
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         if version >= 3:
             timestamp = str(int(time.time()))
@@ -305,6 +344,8 @@ class VDiskViewSet(viewsets.ViewSet):
         :type storagerouter_guid: str
         :param pagecache_ratio: Ratio (0 < x <= 1) of the pagecache size related to the size
         :type pagecache_ratio: float
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         return VDiskController.create_from_template.delay(vdisk_guid=vdisk.guid,
                                                           name=name,
@@ -321,6 +362,8 @@ class VDiskViewSet(viewsets.ViewSet):
         Gets all possible target Storage Routers for a given vDisk (e.g. when cloning, creating from template or moving)
         :param vdisk: The vDisk to get the targets for
         :type vdisk: VDisk
+        :return: A list of StorageRouters on which the current vDisk is not attached, but the vDisk vPool is extended to
+        :rtype: list[ovs.dal.hybrids.storagerouter.StorageRouter]
         """
         return [] if vdisk.vpool is None else [sd.storagerouter for sd in vdisk.vpool.storagedrivers]
 
@@ -334,6 +377,8 @@ class VDiskViewSet(viewsets.ViewSet):
         Delete a given vDisk
         :param vdisk: The vDisk to delete
         :type vdisk: VDisk
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         if len(vdisk.child_vdisks) > 0:
             raise HttpNotAcceptableException(error_description='vDisk has clones',
@@ -350,6 +395,8 @@ class VDiskViewSet(viewsets.ViewSet):
         Deletes a vDisk (template)
         :param vdisk: the vDisk (template) to delete
         :type vdisk: VDisk
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         if not vdisk.is_vtemplate:
             raise HttpNotAcceptableException(error_description='vDisk should be a vTemplate',
@@ -369,6 +416,8 @@ class VDiskViewSet(viewsets.ViewSet):
         Schedule a backend sync on a vdisk
         :param vdisk: vdisk to schedule a backend sync to
         :type vdisk: VDisk
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         return VDiskController.schedule_backend_sync.delay(vdisk_guid=vdisk.guid)
 
@@ -384,6 +433,8 @@ class VDiskViewSet(viewsets.ViewSet):
         :type vdisk: VDisk
         :param tlog_name: TLog name to verify
         :type tlog_name: str
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         return VDiskController.is_volume_synced_up_to_tlog.delay(vdisk_guid=vdisk.guid, tlog_name=tlog_name)
 
@@ -399,6 +450,8 @@ class VDiskViewSet(viewsets.ViewSet):
         :type vdisk: VDisk
         :param snapshot_id: Snapshot to verify
         :type snapshot_id: str
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         return VDiskController.is_volume_synced_up_to_snapshot.delay(vdisk_guid=vdisk.guid, snapshot_id=snapshot_id)
 
@@ -414,6 +467,8 @@ class VDiskViewSet(viewsets.ViewSet):
         :type vdisk: VDisk
         :param new_size: The new size of the vDisk (in bytes)
         :type new_size: int
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         new_size = int(new_size)
         return VDiskController.extend.delay(vdisk_guid=vdisk.guid,
@@ -427,6 +482,8 @@ class VDiskViewSet(viewsets.ViewSet):
     def get_scrub_storagerouters(self):
         """
         Loads a list of suitable StorageRouters for scrubbing the given vDisk
+        :return: A list of StorageRouters which have the SCRUB role
+        :rtype: list[ovs.dal.hybrids.storagerouter.StorageRouter]
         """
         storagerouters = []
         for storagerouter in StorageRouterList.get_storagerouters():
@@ -448,5 +505,7 @@ class VDiskViewSet(viewsets.ViewSet):
         :type vdisk: VDisk
         :param storagerouter_guid: The guid of the StorageRouter to scrub
         :type storagerouter_guid: str
+        :return: Asynchronous result of a CeleryTask
+        :rtype: celery.result.AsyncResult
         """
         return VDiskController.scrub_single_vdisk.delay(vdisk.guid, storagerouter_guid)

--- a/webapps/frontend/app/viewmodels/containers/vdisk.js
+++ b/webapps/frontend/app/viewmodels/containers/vdisk.js
@@ -54,6 +54,7 @@ define([
         self.guid              = ko.observable(guid);
         self.iops              = ko.observable().extend({ smooth: {} }).extend({ format: generic.formatNumber });
         self.isVTemplate       = ko.observable();
+        self.liveStatus        = ko.observable();
         self.loaded            = ko.observable(false);
         self.loading           = ko.observable(false);
         self.loadingConfig     = ko.observable(false);
@@ -221,6 +222,7 @@ define([
             if (data.hasOwnProperty('info')) {
                 self.storedData(data.info.stored);
                 self.namespace(data.info.namespace);
+                self.liveStatus(data.info.live_status);
             }
             if (data.hasOwnProperty('statistics')) {
                 var stats = data.statistics;

--- a/webapps/frontend/app/viewmodels/site/domains.js
+++ b/webapps/frontend/app/viewmodels/site/domains.js
@@ -100,7 +100,7 @@ define([
                 if (domain.guid() === guid && domain.canDelete()) {
                     app.showMessage(
                         $.t('ovs:domains.delete.delete', { what: domain.name() }),
-                        $.t('ovs:generic.areyousure'),
+                        $.t('ovs:generic.are_you_sure'),
                         [$.t('ovs:generic.no'), $.t('ovs:generic.yes')]
                     )
                     .done(function(answer) {

--- a/webapps/frontend/app/viewmodels/site/storagerouter-detail.js
+++ b/webapps/frontend/app/viewmodels/site/storagerouter-detail.js
@@ -39,6 +39,7 @@ define([
         self.vDiskCache               = {};
         self.vDisksHandle             = {};
         self.vDiskHeaders             = [
+            { key: 'status',     value: '',                            width: 30        },
             { key: 'name',       value: $.t('ovs:generic.name'),       width: undefined },
             { key: 'size',       value: $.t('ovs:generic.size'),       width: 100       },
             { key: 'storedData', value: $.t('ovs:generic.storeddata'), width: 110       },

--- a/webapps/frontend/app/viewmodels/site/users.js
+++ b/webapps/frontend/app/viewmodels/site/users.js
@@ -303,7 +303,7 @@ define([
                 if (client.guid() === guid) {
                     app.showMessage(
                         $.t('ovs:users.clients.delete', { what: client.name() }),
-                        $.t('ovs:generic.areyousure'),
+                        $.t('ovs:generic.are_you_sure'),
                         [$.t('ovs:generic.no'), $.t('ovs:generic.yes')]
                     )
                     .done(function(answer) {
@@ -422,7 +422,7 @@ define([
                 if (user.guid() === guid) {
                     app.showMessage(
                         $.t('ovs:users.delete.delete', { what: user.username() }),
-                        $.t('ovs:generic.areyousure'),
+                        $.t('ovs:generic.are_you_sure'),
                         [$.t('ovs:generic.no'), $.t('ovs:generic.yes')]
                     )
                     .done(function(answer) {

--- a/webapps/frontend/app/viewmodels/site/vdisks.js
+++ b/webapps/frontend/app/viewmodels/site/vdisks.js
@@ -36,7 +36,8 @@ define([
             items: [['is_vtemplate', 'EQUALS', false]]
         };
         self.vDiskHeaders        = [
-            { key: 'edge-clients',  value: '',                               width: 30        },
+            { key: 'status',        value: '',                               width: 30        },
+            { key: 'edgeClients',   value: '',                               width: 30        },
             { key: 'name',          value: $.t('ovs:generic.name'),          width: undefined },
             { key: 'vpool',         value: $.t('ovs:generic.vpool'),         width: 110       },
             { key: 'storagerouter', value: $.t('ovs:generic.storagerouter'), width: 150       },

--- a/webapps/frontend/app/viewmodels/site/vpool-detail.js
+++ b/webapps/frontend/app/viewmodels/site/vpool-detail.js
@@ -35,6 +35,7 @@ define([
         self.storageRouterCache = {};
         self.vDiskCache         = {};
         self.vDiskHeaders       = [
+            { key: 'status',     value: '',                            width: 30        },
             { key: 'name',       value: $.t('ovs:generic.name'),       width: undefined },
             { key: 'size',       value: $.t('ovs:generic.size'),       width: 100       },
             { key: 'storedData', value: $.t('ovs:generic.storeddata'), width: 110       },
@@ -196,7 +197,7 @@ define([
                 self.updatingStorageRouters(true);
                 app.showMessage(
                     $.t('ovs:wizards.shrink_vpool.confirm.remove_' + (single === true ? 'single' : 'multi'), { what: sr.name() }),
-                    $.t('ovs:generic.areyousure'),
+                    $.t('ovs:generic.are_you_sure'),
                     [$.t('ovs:generic.yes'), $.t('ovs:generic.no')]
                 )
                     .done(function(answer) {

--- a/webapps/frontend/app/viewmodels/site/vtemplates.js
+++ b/webapps/frontend/app/viewmodels/site/vtemplates.js
@@ -71,7 +71,7 @@ define([
                 if (vd.guid() === guid && vd.childrenGuids().length === 0) {
                     app.showMessage(
                         $.t('ovs:vdisks.remove_vtemplate.title_msg', {what: vd.name()}),
-                        $.t('ovs:generic.areyousure'),
+                        $.t('ovs:generic.are_you_sure'),
                         [$.t('ovs:generic.no'), $.t('ovs:generic.yes')]
                     )
                         .done(function(answer) {

--- a/webapps/frontend/app/views/site/storagerouter-detail.html
+++ b/webapps/frontend/app/views/site/storagerouter-detail.html
@@ -313,14 +313,23 @@ but WITHOUT ANY WARRANTY of any kind.
                                 <span data-bind="visible: loading()" style="position: absolute; top: 7px; left: -15px;">
                                    <i class="fa fa-spin" data-i18n="[html]ovs:icons.loading"></i>
                                 </span>
-                                <a data-bind="html: loaded() ? (name() ? name() : '<i>name not set</i>') : '',
-                                              attr: { href: $root.shared.routing.loadHash('vdisk-detail', { guid: guid }) }"></a>
+                                <div data-bind="status: {
+                                                    colors: {
+                                                        green: liveStatus() === 'RUNNING',
+                                                        orange: liveStatus() === 'NON-RUNNING',
+                                                        red: liveStatus() === 'HALTED'
+                                                    },
+                                                    defaultColor: 'lightgrey'
+                                                }, tooltip: 'ovs:generic.states.vdisk.' + liveStatus()"
+                                     style="width: 14px; height: 14px;">
+                                </div>
                             </td>
+                            <td><a data-bind="html: loaded() ? (name() ? name() : '<i>name not set</i>') : '', attr: { href: $root.shared.routing.loadHash('vdisk-detail', { guid: guid }) }"></a></td>
                             <td><span data-bind="text: size"></span></td>
-                            <td><span data-bind="text: storedData"></span></td>
-                            <td><span data-bind="text: iops"></span></td>
-                            <td><span data-bind="text: readSpeed"></span></td>
-                            <td><span data-bind="text: writeSpeed"></span></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? storedData : '-'"></span></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? iops : '-'"></span></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? readSpeed : '-'"></span></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? writeSpeed : '-'"></span></td>
                             <td>
                                 <div data-bind="status: {
                                                     colors: {
@@ -331,7 +340,8 @@ but WITHOUT ANY WARRANTY of any kind.
                                                     },
                                                     defaultColor: 'lightgrey'
                                                 }, tooltip: 'ovs:generic.states.dtl.' + dtlStatus()"
-                                     style="width: 14px; height: 14px;"></div>
+                                     style="width: 14px; height: 14px;">
+                                </div>
                             </td>
                         </tr>
                     </table>

--- a/webapps/frontend/app/views/site/vdisk-detail.html
+++ b/webapps/frontend/app/views/site/vdisk-detail.html
@@ -35,8 +35,7 @@ but WITHOUT ANY WARRANTY of any kind.
             <li class="actions">
                 <span data-i18n="ovs:generic.actions"></span>:
                 <button type="button" class="btn btn-mini btn-default hand"
-                        style="color: #428bca;"
-                        id="vdisk-snapshot"
+                        id="vdisk-snapshot" style="color: #428bca;"
                         data-bind="click: function() { $root.snapshot(); },
                                    enable: loaded(),
                                    tooltip: 'ovs:vdisks.detail.snapshot',
@@ -44,12 +43,11 @@ but WITHOUT ANY WARRANTY of any kind.
                     <span class="fa hand" data-i18n="[html]ovs:icons.snapshot"></span>
                 </button>
                 <button type="button" class="btn btn-mini btn-default hand"
-                        style="color: #428bca;"
-                        id="vdisk-rollback"
+                        id="vdisk-rollback" style="color: #428bca;"
                         data-bind="click: function() { $root.rollback(); },
                                    tooltip: 'ovs:vdisks.detail.rollback',
                                    enable: $root.shared.user.roles().contains('write') && $root.canBeModified()">
-                    <span class="fa hand" data-i18n="[html]ovs:icons.rollback"></span>
+                    <span class="fa hand fa-flip-horizontal" data-i18n="[html]ovs:icons.rollback"></span>
                 </button>
                 <button type="button" class="btn btn-mini btn-default hand"
                         id="vdisk-clone" style="color: #428bca;"
@@ -81,10 +79,17 @@ but WITHOUT ANY WARRANTY of any kind.
                     <span class="fa hand" data-i18n="[html]ovs:icons.set_as_template"></span>
                 </button>
                 <button type="button" class="btn btn-mini btn-default hand"
+                        id="vdisk-restart" style="color: #428bca;"
+                        data-bind="click: function() { $root.restartVDisk(); },
+                                   tooltip: 'ovs:vdisks.detail.restart',
+                                   enable: $root.shared.user.roles().contains('manage') && liveStatus() !== 'RUNNING' && !$root.restarting()">
+                    <span class="fa hand" data-i18n="[html]ovs:icons.load"></span>
+                </button>
+                <button type="button" class="btn btn-mini btn-default hand"
                         id="vdisk-delete"
                         data-bind="click: function() { $root.removeVDisk(); },
                                    tooltip: childrenGuids().length === 0 ? 'ovs:vdisks.detail.remove' : 'ovs:vdisks.detail.has_children',
-                                   enable: $root.shared.user.roles().contains('manage') && $root.canBeModified(),
+                                   enable: $root.shared.user.roles().contains('manage') && !$root.convertingToTemplate() && !$root.removing() && !$root.restarting(),
                                    style: { color: $root.shared.user.roles().contains('manage') && childrenGuids().length === 0 ? '#428bca' : 'lightgrey' }">
                     <span class="fa hand" data-i18n="[html]ovs:icons.delete"></span>
                 </button>
@@ -101,15 +106,32 @@ but WITHOUT ANY WARRANTY of any kind.
                     </thead>
                     <tbody>
                         <tr>
-                            <td style="width: 15%;" data-i18n="ovs:generic.vpool"></td>
+                            <td style="width: 15%;" data-i18n="ovs:generic.status"></td>
                             <td style="width: 35%;">
+                                <div style="width: 14px; height: 14px;"
+                                     data-bind="tooltip: 'ovs:generic.states.vdisk.' + liveStatus(),
+                                                status: {
+                                                    colors: {
+                                                        green: liveStatus() === 'RUNNING',
+                                                        orange: liveStatus() === 'NON-RUNNING',
+                                                        red: liveStatus() === 'HALTED'
+                                                    },
+                                                    defaultColor: 'lightgrey'
+                                                }">
+                                </div>
+                            <td style="width: 15%;" data-i18n="ovs:generic.iops"></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? iops : '-'"></span></td>
+                        </tr>
+                        <tr>
+                            <td data-i18n="ovs:generic.vpool"></td>
+                            <td>
                                 <span data-bind="lazyloader: { item: vpool, loadedObservable: 'loaded', undefinedLoading: false }">
                                     <a data-part="lazy-entry" data-bind="text: item().name(),
                                                                          attr: { href: $root.shared.routing.loadHash('vpool-detail', { guid: item().guid }) }"></a>
                                 </span>
                             </td>
-                            <td data-i18n="ovs:generic.iops"></td>
-                            <td><span data-bind="text: iops"></span></td>
+                            <td data-i18n="ovs:generic.read_speed"></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? readSpeed : '-'"></span></td>
                         </tr>
                         <tr>
                             <td data-i18n="ovs:generic.storagerouter"></td>
@@ -119,23 +141,22 @@ but WITHOUT ANY WARRANTY of any kind.
                                                                          attr: { href: $root.shared.routing.loadHash('storagerouter-detail', { guid: item().guid }) }"></a>
                                 </span>
                             </td>
-                            <td data-i18n="ovs:generic.read_speed"></td>
-                            <td><span data-bind="text: readSpeed"></span></td>
+                            <td data-i18n="ovs:generic.write_speed"></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? writeSpeed : '-'"></span></td>
                         </tr>
                         <tr>
                             <td data-i18n="ovs:generic.size"></td>
                             <td><span data-bind="text: size"></span></td>
-                            <td data-i18n="ovs:generic.write_speed"></td>
-                            <td><span data-bind="text: writeSpeed"></span></td>
+                            <td colspan="2">&nbsp;</td>
                         </tr>
                         <tr>
                             <td data-i18n="ovs:generic.storeddata"></td>
-                            <td><span data-bind="text: storedData"></span></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? storedData : '-'"></span></td>
                             <td colspan="2">&nbsp;</td>
                         </tr>
                         <tr>
                             <td data-i18n="ovs:generic.nrofsnapshots"></td>
-                            <td><span data-bind="text: snapshots().length"></span></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? snapshots().length : '-'"></span></td>
                             <td colspan="2">&nbsp;</td>
                         </tr>
                         <tr>
@@ -161,7 +182,7 @@ but WITHOUT ANY WARRANTY of any kind.
                         </tr>
                         <tr>
                             <td data-i18n="ovs:generic.namespace"></td>
-                            <td><span data-bind="text: namespace"></span></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? namespace : '-'"></span></td>
                             <td colspan="2">&nbsp;</td>
                         </tr>
                     </tbody>

--- a/webapps/frontend/app/views/site/vdisks.html
+++ b/webapps/frontend/app/views/site/vdisks.html
@@ -32,33 +32,50 @@ but WITHOUT ANY WARRANTY of any kind.
                     <span data-bind="visible: loading()" style="position: absolute; top: 7px; left: -15px;">
                        <i class="fa fa-spin" data-i18n="[html]ovs:icons.loading"></i>
                     </span>
+                    <div data-bind="tooltip: 'ovs:generic.states.vdisk.' + liveStatus(),
+                                    status: {
+                                        colors: {
+                                            green: liveStatus() === 'RUNNING',
+                                            orange: liveStatus() === 'NON-RUNNING',
+                                            red: liveStatus() === 'HALTED'
+                                        },
+                                        defaultColor: 'lightgrey'
+                                    }"
+                         style="width: 14px; height: 14px; margin-top: 1px;">
+                    </div>
+                </td>
+                <td style="position: relative;">
                     <span class="fa pointer" data-i18n="[html]ovs:icons.link" style="margin-top: 1px;"
                           data-bind="tooltip: connectedECText(),
-                                     style: { color: edgeClients().length > 0 ? '#333' : 'lightgrey' }"></span>
+                                     style: { color: edgeClients().length > 0 ? '#333' : 'lightgrey' }">
+                    </span>
                 </td>
                 <td>
                     <a data-bind="html: loaded() ? (name() ? name() : '<i>name not set</i>') : '',
-                                  attr: { href: $root.shared.routing.loadHash('vdisk-detail', { guid: guid }) }"></a>
+                                  attr: { href: $root.shared.routing.loadHash('vdisk-detail', { guid: guid }) }">
+                    </a>
                 </td>
                 <td>
                     <span data-bind="lazyloader: { item: vpool, loadedObservable: 'loaded', undefinedLoading: false }">
                         <a data-part="lazy-entry"
                            data-bind="text: item().name,
-                                      attr: { href: $root.shared.routing.loadHash('vpool-detail', { guid: item().guid }) }"></a>
+                                      attr: { href: $root.shared.routing.loadHash('vpool-detail', { guid: item().guid }) }">
+                        </a>
                     </span>
                 </td>
                 <td>
                     <span data-bind="lazyloader: { item: storageRouter, loadedObservable: 'loaded', undefinedLoading: false }">
                         <a data-part="lazy-entry"
                            data-bind="text: item().name,
-                                      attr: { href: $root.shared.routing.loadHash('storagerouter-detail', { guid: item().guid }) }"></a>
+                                      attr: { href: $root.shared.routing.loadHash('storagerouter-detail', { guid: item().guid }) }">
+                        </a>
                     </span>
                 </td>
                 <td><span data-bind="text: size"></span></td>
-                <td><span data-bind="text: storedData"></span></td>
-                <td><span data-bind="text: iops"></span></td>
-                <td><span data-bind="text: readSpeed"></span></td>
-                <td><span data-bind="text: writeSpeed"></span></td>
+                <td><span data-bind="text: liveStatus() === 'RUNNING' ? storedData : '-'"></span></td>
+                <td><span data-bind="text: liveStatus() === 'RUNNING' ? iops : '-'"></span></td>
+                <td><span data-bind="text: liveStatus() === 'RUNNING' ? readSpeed : '-'"></span></td>
+                <td><span data-bind="text: liveStatus() === 'RUNNING' ? writeSpeed : '-'"></span></td>
                 <td>
                     <div data-bind="status: {
                                         colors: {
@@ -69,7 +86,8 @@ but WITHOUT ANY WARRANTY of any kind.
                                         },
                                         defaultColor: 'lightgrey'
                                     }, tooltip: 'ovs:generic.states.dtl.' + dtlStatus()"
-                         style="width: 14px; height: 14px;"></div>
+                         style="width: 14px; height: 14px;">
+                    </div>
                 </td>
             </tr>
         </table>

--- a/webapps/frontend/app/views/site/vpool-detail.html
+++ b/webapps/frontend/app/views/site/vpool-detail.html
@@ -186,14 +186,23 @@ but WITHOUT ANY WARRANTY of any kind.
                                 <span data-bind="visible: loading()" style="position: absolute; top: 7px; left: -15px;">
                                    <i class="fa fa-spin" data-i18n="[html]ovs:icons.loading"></i>
                                 </span>
-                                <a data-bind="html: loaded() ? (name() ? name() : '<i>name not set</i>') : '',
-                                              attr: { href: $root.shared.routing.loadHash('vdisk-detail', { guid: guid }) }"></a>
+                                <div data-bind="status: {
+                                                    colors: {
+                                                        green: liveStatus() === 'RUNNING',
+                                                        orange: liveStatus() === 'NON-RUNNING',
+                                                        red: liveStatus() === 'HALTED'
+                                                    },
+                                                    defaultColor: 'lightgrey'
+                                                }, tooltip: 'ovs:generic.states.vdisk.' + liveStatus()"
+                                     style="width: 14px; height: 14px;">
+                                </div>
                             </td>
+                            <td><a data-bind="html: loaded() ? (name() ? name() : '<i>name not set</i>') : '', attr: { href: $root.shared.routing.loadHash('vdisk-detail', { guid: guid }) }"></a></td>
                             <td><span data-bind="text: size"></span></td>
-                            <td><span data-bind="text: storedData"></span></td>
-                            <td><span data-bind="text: iops"></span></td>
-                            <td><span data-bind="text: readSpeed"></span></td>
-                            <td><span data-bind="text: writeSpeed"></span></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? storedData : '-'"></span></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? iops : '-'"></span></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? readSpeed : '-'"></span></td>
+                            <td><span data-bind="text: liveStatus() === 'RUNNING' ? writeSpeed : '-'"></span></td>
                             <td>
                                 <div data-bind="status: {
                                                     colors: {

--- a/webapps/frontend/locales/en-US/ovs.json
+++ b/webapps/frontend/locales/en-US/ovs.json
@@ -91,7 +91,7 @@
             "unavailable": "The call is unavailable",
             "unavailable_call": "The call is unavailable in the relay"
         },
-        "areyousure": "Are you sure?",
+        "are_you_sure": "Are you sure?",
         "backend_type": "Type",
         "backendtypes": {
             "alba": "Open vStorage Backend"
@@ -250,6 +250,11 @@
                 "unknown": "Unknown",
                 "warning": "Warning"
             },
+            "vdisk": {
+                "HALTED": "Halted",
+                "NON-RUNNING": "Warning",
+                "RUNNING": "Running"
+            },
             "vpool": {
                 "DELETING": "Deleting",
                 "EXTENDING": "Extending",
@@ -356,7 +361,6 @@
         "snapshot": "&#xf030;",
         "storagerouter": "&#xf0c2;",
         "storagerouter_vpool_link": "&#xf07c;",
-        "sync": "&#xf021;",
         "unlink": "&#xf127;",
         "up": "&#xf106;",
         "vdisks": "&#xf0a0;",
@@ -585,6 +589,7 @@
             "is_clone": "vDisk is a clone",
             "move": "Move",
             "remove": "Remove",
+            "restart": "Restart",
             "rollback": "Rollback",
             "scrub": "Scrub",
             "set_as_template": "Set as vTemplate",
@@ -617,6 +622,14 @@
             "success": "Removed vTemplate",
             "success_msg": "vTemplate __what__ has been removed",
             "title_msg": "Are you sure you want to remove vTemplate __what__?"
+        },
+        "restart_vdisk": {
+            "failed_msg": "Restarting vDisk __what__ failed: __why__",
+            "started": "Restarting vDisk",
+            "started_msg": "vDisk __what__ is being restarted",
+            "success": "Restarted vDisk",
+            "success_msg": "vDisk __what__ has been restarted",
+            "title_msg": "Are you sure you want to restart vDisk __what__?"
         },
         "save_config": {
             "failed_msg": "Saving configuration for vDisk __what__ failed: __why__",


### PR DESCRIPTION
Added global 'Status' field for vDisks on all pages displaying vDisks
Implemented API to restart volumes
Implemented button in GUI to restart volumes (only usable when volume is not running)
Stored data, IOPS, read & write speed is no longer shown for halted or non-running volumes