### PR TITLE
no model changes for LXD_FAKE disks

### DIFF
--- a/ovs/lib/disk.py
+++ b/ovs/lib/disk.py
@@ -164,6 +164,8 @@ class DiskController(object):
 
         # Sync the model
         for disk in storagerouter.disks:
+            if disk.model == 'LXD_FAKE':
+                continue
             disk_info = None
             for alias in disk.aliases:
                 if alias in alias_name_mapping:

--- a/ovs/lib/storagerouter.py
+++ b/ovs/lib/storagerouter.py
@@ -327,6 +327,9 @@ class StorageRouterController(object):
                 if role not in [DiskPartition.ROLES.DB, DiskPartition.ROLES.DTL, DiskPartition.ROLES.WRITE, DiskPartition.ROLES.SCRUB]:
                     continue
                 for part in part_info:
+                    dpart = DiskPartition(part['guid'])
+                    if dpart.disk.model == 'LXD_FAKE':
+                        continue
                     if not client.is_mounted(part['mountpoint']) and part['mountpoint'] != DiskPartition.VIRTUAL_STORAGE_LOCATION:
                         error_messages.append('Mount point {0} is not mounted'.format(part['mountpoint']))
 


### PR DESCRIPTION
hack for skipping disks created with model == 'LXD_FAKE' for use in lxd containers