### PR TITLE
Support agent changes

### DIFF
--- a/docs/support_agent.md
+++ b/docs/support_agent.md
@@ -1,0 +1,31 @@
+### The support agent
+The support agent is a small process (ovs-support-agent) which sends heartbeat data towards the OpenvStorage monitoring server.
+It is also capable of processing certain tasks so that the OpenvStorage team can easily provide support for this cluster.
+
+### Configuring the agent
+Tweaking the agent is done using the GUI:
+![Alt text](https://user-images.githubusercontent.com/17570109/32617221-b056ff26-c574-11e7-8359-bc1a4eec32ce.png "Configuring support agent")
+
+All aspects about the support agent can be tweaked:
+ - Heartbeat can be enabled/disabled (Enables or disables the agent as a whole)
+ - Task processing can be enabled/disabled:
+   - Task: remote access: the monitoring agent opens a tunnel towards the OpenvStorage monitoring server upon request
+   - Task: upload log files: the monitoring agent uploads log files on the OpenvStorage monitoring ftp server
+
+### The agent during failures
+The support agent is capable of running under every circumstance. When the configuration management is no longer available, 
+the agent will be looking for user settings under /opt/OpenvStorage/config/support_agent.json. When the option could not be found, 
+the agent will default to idling and can only be activated via a manual intervention.
+
+The /opt/OpenvStorage/config/support_agent.json is an optional file which can provide default behaviour for the support agent when all else fails.
+This file is of a JSON format.
+
+Possible settings for /opt/OpenvStorage/config/support_agent.json:
+```
+{
+    "support_agent": true or false. Indicates if the support agent should run when the user setting could not be fetched from the config management.
+    Note: The support agent will always send it's heartbeat when abled.
+    "remote_access": true or false. Indicates if the support agent should process tasks given by the OpenvStorage monitoring server..
+    "interval": <float>. Indicates the loop interval (in seconds) for the support agent.
+} 
+```

--- a/ovs/extensions/generic/logger.py
+++ b/ovs/extensions/generic/logger.py
@@ -17,7 +17,7 @@
 """
 Contains the Logger module
 """
-
+from ovs_extensions.db.arakoon.pyrakoon.pyrakoon.compat import ArakoonException
 from ovs.extensions.generic.configuration import Configuration, NotFoundException
 from ovs_extensions.log.logger import Logger as _Logger
 
@@ -43,5 +43,5 @@ class Logger(_Logger):
         """
         try:
             return Configuration.get('/ovs/framework/logging')
-        except (IOError, NotFoundException):
+        except (IOError, NotFoundException, ArakoonException):
             return {}

--- a/ovs/extensions/packages/packagefactory.py
+++ b/ovs/extensions/packages/packagefactory.py
@@ -27,7 +27,7 @@ class PackageFactory(_PackageFactory):
     """
     Factory class returning specialized classes
     """
-    _logger = Logger('package_factory')
+    _logger = Logger('extensions-packages')
 
     universal_packages = ['arakoon', 'openvstorage', 'openvstorage-backend', 'openvstorage-sdm']
     ose_only_packages = ['alba', 'volumedriver-no-dedup-base', 'volumedriver-no-dedup-server']

--- a/ovs/extensions/packages/packagefactory.py
+++ b/ovs/extensions/packages/packagefactory.py
@@ -17,7 +17,9 @@
 """
 Package Factory module
 """
+from ovs_extensions.db.arakoon.pyrakoon.pyrakoon.compat import ArakoonException
 from ovs.extensions.generic.configuration import Configuration
+from ovs.extensions.generic.logger import Logger
 from ovs_extensions.packages.packagefactory import PackageFactory as _PackageFactory
 
 
@@ -25,6 +27,8 @@ class PackageFactory(_PackageFactory):
     """
     Factory class returning specialized classes
     """
+    _logger = Logger('package_factory')
+
     universal_packages = ['arakoon', 'openvstorage', 'openvstorage-backend', 'openvstorage-sdm']
     ose_only_packages = ['alba', 'volumedriver-no-dedup-base', 'volumedriver-no-dedup-server']
     ee_only_packages = ['alba-ee', 'volumedriver-ee-base', 'volumedriver-ee-server']
@@ -35,20 +39,21 @@ class PackageFactory(_PackageFactory):
 
     @classmethod
     def _get_packages(cls):
-        if Configuration.exists('/ovs/framework/edition'):
-            edition = Configuration.get('/ovs/framework/edition')
-            if edition == 'community':
-                package_names = cls.ose_only_packages
-                binaries = cls.ose_only_binaries
-            elif edition == 'enterprise':
-                package_names = cls.ee_only_packages
-                binaries = cls.ee_only_binaries
-            else:
-                raise ValueError('Edition could not be found in configuration')
-        else:
-            package_names = cls.ose_only_packages + cls.ee_only_packages
-            binaries = cls.ose_only_binaries + cls.ee_only_binaries
-
+        package_names = cls.ose_only_packages + cls.ee_only_packages
+        binaries = cls.ose_only_binaries + cls.ee_only_binaries
+        try:
+            if Configuration.exists('/ovs/framework/edition'):
+                edition = Configuration.get('/ovs/framework/edition')
+                if edition == 'community':
+                    package_names = cls.ose_only_packages
+                    binaries = cls.ose_only_binaries
+                elif edition == 'enterprise':
+                    package_names = cls.ee_only_packages
+                    binaries = cls.ee_only_binaries
+                else:
+                    raise ValueError('Edition could not be found in configuration')
+        except ArakoonException:
+            cls._logger.exception('Unable to connect to the configuration Arakoon. Returning all packages/binaries')
         return {'names': package_names + cls.universal_packages,
                 'binaries': binaries + cls.universal_binaries}
 

--- a/ovs/extensions/storage/persistentfactory.py
+++ b/ovs/extensions/storage/persistentfactory.py
@@ -28,7 +28,7 @@ class PersistentFactory(_PersistentFactory):
 
     @classmethod
     def _get_store_info(cls):
-        client_type = Configuration.get('/ovs/framework/stores|persistent')
+        client_type = cls._get_client_type()
         if client_type not in ['pyrakoon', 'arakoon']:
             raise RuntimeError('Configured client type {0} is not implemented'.format(client_type))
         cluster = Configuration.get('/ovs/framework/arakoon_clusters|ovsdb')

--- a/ovs/extensions/support/agent.py
+++ b/ovs/extensions/support/agent.py
@@ -61,18 +61,20 @@ class SupportAgent(object):
         try:
             # Might fail when Arakoon would be down
             self._cluster_id = Configuration.get(self.LOCATION_CLUSTER_ID).replace(r"'", r"'\''")
-        except:
+        except Exception:
             self._logger.exception(self.CONFIGURATION_MESSAGE.format(self.LOCATION_CLUSTER_ID))
             # Fall back to the config file
             with open(Configuration.CONFIG_STORE_LOCATION, 'r') as config_file:
                 config = json.load(config_file)
-                if 'cluster_id' in config:
-                    self._cluster_id = config['cluster_id']
-                else:
-                    raise
+                self._logger.info(config)
+            if 'cluster_id' in config:
+                self._cluster_id = config['cluster_id']
+            else:
+                raise RuntimeError('Could not find "cluster_id" within {0} or the configuration Arakoon. Stopping...'
+                                   .format(Configuration.CONFIG_STORE_LOCATION))
         try:
             self.interval = Configuration.get(self.LOCATION_INTERVAL, default=self.DEFAULT_INTERVAL)
-        except:
+        except Exception:
             self._logger.exception(self.CONFIGURATION_MESSAGE.format(self.LOCATION_INTERVAL))
             self.interval = self.DEFAULT_INTERVAL
 
@@ -105,7 +107,7 @@ class SupportAgent(object):
         :rtype: NoneType or ovs.extensions.generic.sshclient.SSHClient
         """
         if self._storagerouter is None:
-            logger.exception('Unable to build a local client, no storagerouter was found to use.')
+            logger.error('Unable to build a local client, no storagerouter was found to use.')
             return
         else:
             if self._client is None:

--- a/ovs/extensions/support/agent.py
+++ b/ovs/extensions/support/agent.py
@@ -287,7 +287,7 @@ class SupportAgent(object):
         try:
             remote_access_enabled = Configuration.get(self.LOCATION_REMOTE_ACCESS)
         except Exception:
-            remote_access_enabled = True
+            remote_access_enabled = False
             self._logger.exception(self.CONFIGURATION_MESSAGE.format(self.LOCATION_REMOTE_ACCESS))
         if remote_access_enabled is True:
             try:
@@ -310,7 +310,7 @@ if __name__ == '__main__':
     try:
         support_agent_enabled = Configuration.get(SupportAgent.LOCATION_SUPPORT_AGENT)
     except Exception:
-        support_agent_enabled = True
+        support_agent_enabled = False
         logger.exception(SupportAgent.CONFIGURATION_MESSAGE.format(SupportAgent.LOCATION_SUPPORT_AGENT))
 
     if support_agent_enabled is False:

--- a/ovs/extensions/support/agent.py
+++ b/ovs/extensions/support/agent.py
@@ -50,6 +50,8 @@ class SupportAgent(object):
         self._package_manager = PackageFactory.get_manager()
         self._service_manager = ServiceFactory.get_manager()
         self._client = SSHClient(endpoint=self._storagerouter)
+        self._node_id = self._storagerouter.machine_id.replace(r"'", r"'\''")
+        self._openvpn_service_name = 'openvpn@ovs_{0}-{1}'.format(self._cluster_id, self._node_id)
 
         self.interval = Configuration.get('/ovs/framework/support|interval', default=60)
 
@@ -104,37 +106,12 @@ class SupportAgent(object):
         """
         try:
             SupportAgent._logger.debug('Processing: {0}'.format(task_code))
-            node_id = self._storagerouter.machine_id.replace(r"'", r"'\''")
-            service_name = 'openvpn@ovs_{0}-{1}'.format(self._cluster_id, node_id)
-
             if task_code == 'OPEN_TUNNEL':
-                if self._service_type == 'upstart':
-                    check_output('service openvpn stop', shell=True)
-                else:
-                    check_output("systemctl stop '{0}' || true".format(service_name), shell=True)
-                check_output('rm -f /etc/openvpn/ovs_*', shell=True)
-                for filename, contents in metadata['files'].iteritems():
-                    with open(filename, 'w') as the_file:
-                        the_file.write(base64.b64decode(contents))
-                if self._service_type == 'upstart':
-                    check_output('service openvpn start', shell=True)
-                else:
-                    check_output("systemctl start '{0}'".format(service_name), shell=True)
+                self.open_tunnel(metadata)
             elif task_code == 'CLOSE_TUNNEL':
-                if self._service_type == 'upstart':
-                    check_output('service openvpn stop', shell=True)
-                else:
-                    check_output("systemctl stop '{0}'".format(service_name), shell=True)
-                check_output('rm -f /etc/openvpn/ovs_*', shell=True)
+                self.close_tunnel(metadata)
             elif task_code == 'UPLOAD_LOGFILES':
-                logfile = check_output('ovs collect logs', shell=True).strip()
-                check_output("mv '{0}' '/tmp/{1}'; curl -T '/tmp/{1}' 'ftp://{2}' --user '{3}:{4}'; rm -f '{0}' '/tmp/{1}'".format(
-                    logfile.replace(r"'", r"'\''"),
-                    metadata['filename'].replace(r"'", r"'\''"),
-                    metadata['endpoint'].replace(r"'", r"'\''"),
-                    metadata['user'].replace(r"'", r"'\''"),
-                    metadata['password'].replace(r"'", r"'\''")
-                ), shell=True)
+                self.upload_files(metadata)
             else:
                 raise RuntimeError('Unknown task')
         except Exception:
@@ -143,18 +120,93 @@ class SupportAgent(object):
         finally:
             SupportAgent._logger.debug('Completed')
 
+    def open_tunnel(self, metadata):
+        """
+        Opens up the openvpn tunnel
+        :param metadata: Metadata about the files to use for tunnel
+        :type metadata: dict
+        Example: {'files': {...}}.
+        The files dict will contain file names (keys) and their contents (value) Example: {my_file: my_file_contents}
+        These files will always be /etc/openvpn/ovs_ + 'ca.crt', 'ta.key', '{0}.crt'.format(identifier), '{0}.key'.format(identifier), '{0}.conf'.format(identifier)
+        with identifier = cluster id + node id
+        :return: None
+        :rtype: NoneType
+        """
+        # Close tunnel and update configs
+        self.close_tunnel(metadata)
+        for filename, contents in metadata['files'].iteritems():
+            with open(filename, 'w') as the_file:
+                the_file.write(base64.b64decode(contents))
+        if self._service_type == 'upstart':
+            check_output('service openvpn start', shell=True)
+        else:
+            check_output("systemctl start '{0}'".format(self._openvpn_service_name), shell=True)
+
+    @staticmethod
+    def upload_files(metadata):
+        """
+        Upload the collected log files to a destination
+        :param metadata: Metadata about the destination.
+        Example: {'filename': name to upload the tarball as, 'endpoint': ip of the ftp, 'user': an ftp user, 'password': ftp users password}
+        :type metadata: dict
+        :return: None
+        :rtype: NoneType
+        """
+        logfile = check_output('ovs collect logs', shell=True).strip()
+        check_output("mv '{0}' '/tmp/{1}'; curl -T '/tmp/{1}' 'ftp://{2}' --user '{3}:{4}'; rm -f '{0}' '/tmp/{1}'".format(
+            logfile.replace(r"'", r"'\''"),
+            metadata['filename'].replace(r"'", r"'\''"),
+            metadata['endpoint'].replace(r"'", r"'\''"),
+            metadata['user'].replace(r"'", r"'\''"),
+            metadata['password'].replace(r"'", r"'\''")), shell=True)
+
+    def close_tunnel(self, metadata):
+        """
+        Closes the openvpn tunnel
+        @TODO: only close the ovs remote tunnel on 14.04 (all tunnels are currently closed)
+        :param metadata: Metadata for the task (empty dict for close tunnel)
+        :type metadata: dict
+        :return: None
+        :rtype: NoneType
+        """
+        _ = metadata
+        if self._service_type == 'upstart':
+            check_output('service openvpn stop', shell=True)
+        else:
+            check_output("systemctl stop '{0}'".format(self._openvpn_service_name), shell=True)
+        check_output('rm -f /etc/openvpn/ovs_*', shell=True)
+
+    def _send_heartbeat(self):
+        """
+        Send heart beat to the monitoring server
+        :raises RuntimeError when in valid status code is returned by the api
+        :return: Returns the response from the server
+        Example return: {u'tasks': [{'code': 'OPEN_TUNNEL', 'metadata': {'files': {'/etc/openvpn/ovs_ca.crt': 'CERTIFACTECONTENTS'}}}]}
+        The tasks returned from the server are classified by a task code which is one of the following: OPEN_TUNNEL, CLOSE_TUNNEL, UPLOAD_LOGFILES
+        - OPEN TUNNEL tasks receive metadata which has a files entry. Example: {'metadata': {'files': {...}}}.
+          The files dict will contain file names (keys) and their contents (value) Example: {my_file: my_file_contents}
+          These files will always be /etc/openvpn/ovs_ + 'ca.crt', 'ta.key', '{0}.crt'.format(identifier), '{0}.key'.format(identifier), '{0}.conf'.format(identifier)
+          with identifier = cluster id + node id
+        - CLOSE TUNNEL tasks have no metadata
+        - UPLOAD_LOGFILES tasks receive metadata about where to upload tar balled logs
+          Example: {'metadata': {'filename': name to upload the tarball as, 'endpoint': ip of the ftp, 'user': an ftp user, 'password': ftp users password}}
+        :rtype: dict
+        """
+        response = requests.post(url='https://monitoring.openvstorage.com/api/support/heartbeat/',
+                                 data={'data': json.dumps(self.get_heartbeat_data())},
+                                 headers={'Accept': 'application/json; version=1'})
+        if response.status_code != 200:
+            raise RuntimeError('Received invalid status code: {0} - {1}'.format(response.status_code, response.text))
+        return response.json()
+
     def run(self):
         """
         Executes a call
         """
-        SupportAgent._logger.debug('Processing heartbeat')
+        self._logger.debug('Processing heartbeat')
         try:
-            response = requests.post(url='https://monitoring.openvstorage.com/api/support/heartbeat/',
-                                     data={'data': json.dumps(self.get_heartbeat_data())},
-                                     headers={'Accept': 'application/json; version=1'})
-            if response.status_code != 200:
-                raise RuntimeError('Received invalid status code: {0} - {1}'.format(response.status_code, response.text))
-            return_data = response.json()
+            return_data = self._send_heartbeat()
+            self._logger.debug('Requested return data: {0}'.format(return_data))
         except Exception:
             SupportAgent._logger.exception('Unexpected error during support call')
             raise
@@ -164,7 +216,7 @@ class SupportAgent(object):
             self._storagerouter.last_heartbeat = time.time()
             self._storagerouter.save()
         except Exception:
-            SupportAgent._logger.exception('Could not save last heartbeat timestamp')
+            self._logger.exception('Could not save last heartbeat timestamp')
             # Ignore this error, it's not mandatory for the support agent
 
         if Configuration.get('/ovs/framework/support|remote_access') is True:
@@ -172,9 +224,10 @@ class SupportAgent(object):
                 for task in return_data['tasks']:
                     self._process_task(task['code'], task['metadata'])
             except Exception:
-                SupportAgent._logger.exception('Unexpected error processing tasks')
+                self._logger.exception('Unexpected error processing tasks')
                 raise
 
+        # Currently not returned by the monitoring server
         if 'interval' in return_data:
             interval = return_data['interval']
             if interval != self.interval:

--- a/ovs/lib/migration.py
+++ b/ovs/lib/migration.py
@@ -19,6 +19,7 @@ MigrationController module
 """
 
 import copy
+import json
 from ovs.extensions.generic.logger import Logger
 from ovs.lib.helpers.decorators import ovs_task
 from ovs.lib.helpers.toolbox import Schedule
@@ -390,7 +391,6 @@ class MigrationController(object):
             except Exception:
                 MigrationController._logger.exception('Integration of stats monkey failed')
 
-
         ######################################
         # change to edition key
         if Configuration.get(key='/ovs/framework/edition', default=False) not in ['community', 'enterprise']:
@@ -405,4 +405,18 @@ class MigrationController(object):
                         MigrationController._logger.exception('StorageRouter {0} did not yield edition value'.format(sr.name))
             except Exception:
                 MigrationController._logger.exception('Introduction of version key failed')
+
+        ######################################################
+        # Write away cluster id to a file for back-up purposes
+        try:
+            cluster_id = Configuration.get(key='/ovs/framework/cluster_id', default=None)
+            with open(Configuration.CONFIG_STORE_LOCATION, 'r') as config_file:
+                config = json.load(config_file)
+            if cluster_id is not None and config.get('cluster_id', None) is None:
+                config['cluster_id'] = cluster_id
+                with open(Configuration.CONFIG_STORE_LOCATION, 'w') as config_file:
+                    json.dump(config, config_file, indent=4)
+        except Exception:
+            MigrationController._logger.exception('Writing cluster id to a file failed.')
+
         MigrationController._logger.info('Finished out of band migrations')

--- a/ovs/lib/nodeinstallation.py
+++ b/ovs/lib/nodeinstallation.py
@@ -731,7 +731,8 @@ class NodeInstallationController(object):
         bootstrap_location = Configuration.CONFIG_STORE_LOCATION
         if not target_client.file_exists(bootstrap_location):
             target_client.file_create(bootstrap_location)
-        target_client.file_write(bootstrap_location, json.dumps({'configuration_store': 'arakoon'}, indent=4))
+        framework_config = {'configuration_store': 'arakoon'}
+        target_client.file_write(bootstrap_location, json.dumps(framework_config, indent=4))
 
         Toolbox.log(logger=NodeInstallationController._logger, messages='Setting up configuration Arakoon')
 
@@ -756,6 +757,10 @@ class NodeInstallationController(object):
 
         Configuration.initialize(external_config=external_config, logging_target=logging_target)
         Configuration.initialize_host(machine_id)
+
+        # Write away cluster id to let the support agent read it when Arakoon is down
+        framework_config['cluster_id'] = Configuration.get('/ovs/framework/cluster_id')
+        target_client.file_write(Configuration.CONFIG_STORE_LOCATION, json.dumps(framework_config, indent=4))
 
         if rdma is None:
             rdma = Interactive.ask_yesno(message='Enable RDMA?', default_value=False)

--- a/ovs/lib/nodeinstallation.py
+++ b/ovs/lib/nodeinstallation.py
@@ -728,11 +728,10 @@ class NodeInstallationController(object):
                     Interactive.ask_continue()
                 external_config = True
 
-        bootstrap_location = Configuration.CONFIG_STORE_LOCATION
-        if not target_client.file_exists(bootstrap_location):
-            target_client.file_create(bootstrap_location)
+        if not target_client.file_exists(Configuration.CONFIG_STORE_LOCATION):
+            target_client.file_create(Configuration.CONFIG_STORE_LOCATION)
         framework_config = {'configuration_store': 'arakoon'}
-        target_client.file_write(bootstrap_location, json.dumps(framework_config, indent=4))
+        target_client.file_write(Configuration.CONFIG_STORE_LOCATION, json.dumps(framework_config, indent=4))
 
         Toolbox.log(logger=NodeInstallationController._logger, messages='Setting up configuration Arakoon')
 


### PR DESCRIPTION
### Changes to the support agent:
The support agent is able to run in all failure cases (Arakoon, DAL failures, RabbitMQ) and has a minimal amount of dependencies on other Framework code.

When Arakoon/DAL would be down, all user made setting can no longer be fetched and will revert to defaults. These defaults enable everything by default so support from OVS would be possible.

The only case in which the tunnel could not be opened is when the monitoring server is no longer accessible. It is still possible to open a tunnel by placing the configs manually (these would be provided by our ops) and running the SupportAgent.open_tunnel()