### PR TITLE
- Scheduling no longer checks for controller to inherit from object

### DIFF
--- a/ovs/celery_beat.py
+++ b/ovs/celery_beat.py
@@ -76,9 +76,7 @@ class DistributedScheduler(Scheduler):
                 name = filename.replace('.py', '')
                 mod = imp.load_source(name, '/'.join([path, filename]))
                 for member in inspect.getmembers(mod):
-                    if inspect.isclass(member[1]) \
-                            and member[1].__module__ == name \
-                            and 'object' in [base.__name__ for base in member[1].__bases__]:
+                    if inspect.isclass(member[1]) and member[1].__module__ == name:
                         for submember in inspect.getmembers(member[1]):
                             if hasattr(submember[1], 'schedule') and (isinstance(submember[1].schedule, crontab) or
                                                                       isinstance(submember[1].schedule, timedelta) or

--- a/ovs/lib/mdsservice.py
+++ b/ovs/lib/mdsservice.py
@@ -140,7 +140,7 @@ class MDSServiceController(MDSShared):
                         raise
 
     @staticmethod
-    @ovs_task(name='ovs.mds.mds_checkup', schedule=Schedule(minute='30', hour='0,4,8,12,16,20'), ensure_single_info={'mode': 'DEFAULT'})
+    @ovs_task(name='ovs.mds.mds_checkup', schedule=Schedule(minute='30', hour='0,4,8,12,16,20'), ensure_single_info={'mode': 'CHAINED'})
     def mds_checkup():
         """
         Validates the current MDS setup/configuration and takes actions where required
@@ -451,7 +451,7 @@ class MDSServiceController(MDSShared):
             pass
 
     @staticmethod
-    @ovs_task(name='ovs.mds.mds_catchup', schedule=Schedule(minute='30', hour='*/2'), ensure_single_info={'mode': 'CHAINED'})
+    @ovs_task(name='ovs.mds.mds_catchup', schedule=Schedule(minute='30', hour='*/2'), ensure_single_info={'mode': 'DEFAULT'})
     def mds_catchup():
         """
         Looks to catch up all MDS slaves which are too far behind

--- a/ovs/lib/mdsservice.py
+++ b/ovs/lib/mdsservice.py
@@ -27,14 +27,16 @@ import collections
 from ovs.dal.hybrids.diskpartition import DiskPartition
 from ovs.dal.hybrids.j_storagedriverpartition import StorageDriverPartition
 from ovs.dal.lists.storagerouterlist import StorageRouterList
+from ovs.dal.lists.vdisklist import VDiskList
 from ovs.dal.lists.vpoollist import VPoolList
 from ovs.extensions.generic.configuration import Configuration, NotFoundException
 from ovs.extensions.generic.sshclient import SSHClient, UnableToConnectException
 from ovs_extensions.generic.toolbox import ExtensionsToolbox
 from ovs.extensions.storageserver.storagedriver import MDSMetaDataBackendConfig, MDSNodeConfig, StorageDriverConfiguration
 from ovs.lib.helpers.decorators import ovs_task
-from ovs.lib.helpers.mds.shared import MDSShared
+from ovs.lib.helpers.mds.catchup import MDSCatchUp
 from ovs.lib.helpers.mds.safety import SafetyEnsurer
+from ovs.lib.helpers.mds.shared import MDSShared
 from ovs.lib.helpers.toolbox import Schedule
 from ovs.log.log_handler import LogHandler
 from volumedriver.storagerouter import storagerouterclient
@@ -138,7 +140,7 @@ class MDSServiceController(MDSShared):
                         raise
 
     @staticmethod
-    @ovs_task(name='ovs.mds.mds_checkup', schedule=Schedule(minute='30', hour='0,4,8,12,16,20'), ensure_single_info={'mode': 'CHAINED'})
+    @ovs_task(name='ovs.mds.mds_checkup', schedule=Schedule(minute='30', hour='0,4,8,12,16,20'), ensure_single_info={'mode': 'DEFAULT'})
     def mds_checkup():
         """
         Validates the current MDS setup/configuration and takes actions where required
@@ -447,3 +449,24 @@ class MDSServiceController(MDSShared):
                 time.sleep(1)
         except KeyboardInterrupt:
             pass
+
+    @staticmethod
+    @ovs_task(name='ovs.mds.mds_catchup', schedule=Schedule(minute='30', hour='*/2'), ensure_single_info={'mode': 'CHAINED'})
+    def mds_catchup():
+        """
+        Looks to catch up all MDS slaves which are too far behind
+        """
+        catch_ups = []
+        for vdisk in VDiskList.get_vdisks():
+            catch_up = MDSCatchUp(vdisk.guid)
+            catch_up.catch_up(async=True)
+            catch_ups.append(catch_up)
+        errors = []
+        for catch_up in catch_ups:
+            try:
+                catch_up.wait()
+            except Exception as ex:
+                MDSServiceController._logger.exception('Exceptions while catching for vDisk {0}'.format(catch_up.vdisk.guid))
+                errors.append(str(ex))
+        if len(errors) > 0:
+            raise RuntimeError('Exception occurred while catching up: \n - {0}'.format('\n - '.join(errors)))


### PR DESCRIPTION
- Scrubber: NotFoundExceptions are properly caught
- MDSService: Added the catchup to a task (migration disables it by default)