### PR TITLE
Unify config paths in managers

### DIFF
--- a/ovs/extensions/generic/configuration.py
+++ b/ovs/extensions/generic/configuration.py
@@ -25,16 +25,13 @@ import string
 # noinspection PyUnresolvedReferences
 from ovs_extensions.caching.decorators import cache_file
 from ovs_extensions.generic.configuration import Configuration as _Configuration, ConnectionException, NotFoundException
+from ovs_extensions.constants.config import CONFIG_STORE_LOCATION
 
 
 class Configuration(_Configuration):
     """
     Extends the 'default' configuration class
     """
-    ARAKOON_NAME = 'cacc'
-    ARAKOON_NAME_UNITTEST = 'unittest-cacc'
-    CACC_LOCATION = '/opt/OpenvStorage/config/arakoon_cacc.ini'
-    CONFIG_STORE_LOCATION = '/opt/OpenvStorage/config/framework.json'
 
     base_config = {'cluster_id': None,
                    'external_config': None,
@@ -135,7 +132,7 @@ class Configuration(_Configuration):
         :return: The configured store
         :rtype: str
         """
-        with open(cls.CONFIG_STORE_LOCATION) as config_file:
+        with open(CONFIG_STORE_LOCATION) as config_file:
             contents = json.load(config_file)
             return contents['configuration_store']
 

--- a/ovs/extensions/generic/watcher.py
+++ b/ovs/extensions/generic/watcher.py
@@ -25,6 +25,7 @@ import time
 import pika
 import uuid
 import argparse
+from ovs_extensions.constants.config import ARAKOON_NAME, CACC_LOCATION
 from ovs_extensions.db.arakoon.pyrakoon.pyrakoon.compat import NoGuarantee
 from ovs.extensions.db.arakooninstaller import ArakoonInstaller, ArakoonClusterConfig
 from ovs.extensions.generic.configuration import Configuration
@@ -141,9 +142,9 @@ class Watcher(object):
                     self.log_message('  Error during configuration store test: {0}'.format(ex), 2)
                     return False
 
-                with open(Configuration.CACC_LOCATION) as config_file:
+                with open(CACC_LOCATION) as config_file:
                     contents = config_file.read()
-                config = ArakoonClusterConfig(cluster_id=Configuration.ARAKOON_NAME, load_config=False)
+                config = ArakoonClusterConfig(cluster_id=ARAKOON_NAME, load_config=False)
                 config.read_config(contents=contents)
                 client = ArakoonInstaller.build_client(config)
                 contents = client.get(ArakoonInstaller.INTERNAL_CONFIG_KEY, consistency=NoGuarantee())
@@ -153,12 +154,12 @@ class Watcher(object):
                     except Exception as ex:
                         self.log_message('  Configuration stored in configuration store seems to be corrupt: {0}'.format(ex), 2)
                         return False
-                    temp_filename = '{0}~'.format(Configuration.CACC_LOCATION)
+                    temp_filename = '{0}~'.format(CACC_LOCATION)
                     with open(temp_filename, 'w') as config_file:
                         config_file.write(contents)
                         config_file.flush()
                         os.fsync(config_file)
-                    os.rename(temp_filename, Configuration.CACC_LOCATION)
+                    os.rename(temp_filename, CACC_LOCATION)
                     Watcher.LOG_CONTENTS = contents
                 self.log_message('  Configuration store OK', 0)
 

--- a/ovs/extensions/support/agent.py
+++ b/ovs/extensions/support/agent.py
@@ -34,8 +34,8 @@ from ovs.extensions.generic.sshclient import SSHClient
 from ovs.extensions.generic.system import System
 from ovs.extensions.packages.packagefactory import PackageFactory
 from ovs.extensions.services.servicefactory import ServiceFactory
+from ovs_extensions.constants.config import CONFIG_STORE_LOCATION
 from ovs.lib.helpers.toolbox import Toolbox
-
 
 class ConfigurationNotFoundError(RuntimeError):
     """
@@ -120,7 +120,7 @@ class SupportAgent(object):
             raise NotImplementedError('Only Systemd is supported')
 
         # Potential failing calls
-        self._cluster_id = self.get_config_key(self.LOCATION_CLUSTER_ID, fallback=[Configuration.CONFIG_STORE_LOCATION, 'cluster_id'])
+        self._cluster_id = self.get_config_key(self.LOCATION_CLUSTER_ID, fallback=[CONFIG_STORE_LOCATION, 'cluster_id'])
         self.interval = self.get_config_key(self.LOCATION_INTERVAL, fallback=[self.FALLBACK_CONFIG, self.KEY_INTERVAL], default=self.DEFAULT_INTERVAL)
         self._openvpn_service_name = 'openvpn@ovs_{0}-{1}'.format(self._cluster_id, self._node_id)
 

--- a/ovs/lib/generic.py
+++ b/ovs/lib/generic.py
@@ -24,12 +24,12 @@ import time
 from datetime import datetime, timedelta
 from threading import Thread
 from time import mktime
+from ovs_extensions.constants.config import ARAKOON_NAME, ARAKOON_NAME_UNITTEST
 from ovs.dal.hybrids.servicetype import ServiceType
 from ovs.dal.lists.servicelist import ServiceList
 from ovs.dal.lists.storagerouterlist import StorageRouterList
 from ovs.dal.lists.vdisklist import VDiskList
 from ovs.extensions.db.arakooninstaller import ArakoonClusterConfig
-from ovs.extensions.generic.configuration import Configuration
 from ovs.extensions.generic.logger import Logger
 from ovs.extensions.generic.sshclient import NotAuthenticatedException, SSHClient, UnableToConnectException
 from ovs_extensions.generic.toolbox import ExtensionsToolbox
@@ -37,8 +37,6 @@ from ovs.extensions.packages.packagefactory import PackageFactory
 from ovs.lib.helpers.decorators import ovs_task
 from ovs.lib.helpers.generic.scrubber import Scrubber
 from ovs.lib.helpers.toolbox import Toolbox, Schedule
-from ovs.lib.helpers.storagedriver.installer import StorageDriverInstaller
-from ovs.lib.mdsservice import MDSServiceController
 from ovs.lib.vdisk import VDiskController
 
 
@@ -240,7 +238,7 @@ class GenericController(object):
                                                                      ServiceType.SERVICE_TYPES.NS_MGR,
                                                                      ServiceType.SERVICE_TYPES.ALBA_MGR):
                 cluster = ExtensionsToolbox.remove_prefix(service.name, 'arakoon-')
-                if cluster in cluster_names and cluster not in [Configuration.ARAKOON_NAME, Configuration.ARAKOON_NAME_UNITTEST]:
+                if cluster in cluster_names and cluster not in [ARAKOON_NAME, ARAKOON_NAME_UNITTEST]:
                     continue
                 cluster_names.append(cluster)
                 cluster_info.append((cluster, service.storagerouter))
@@ -248,7 +246,7 @@ class GenericController(object):
         cluster_config_map = {}
         for cluster, storagerouter in cluster_info:
             GenericController._logger.debug('  Collecting info for cluster {0}'.format(cluster))
-            ip = storagerouter.ip if cluster in [Configuration.ARAKOON_NAME, Configuration.ARAKOON_NAME_UNITTEST] else None
+            ip = storagerouter.ip if cluster in [ARAKOON_NAME, ARAKOON_NAME_UNITTEST] else None
             try:
                 config = ArakoonClusterConfig(cluster_id=cluster, source_ip=ip)
                 cluster_config_map[cluster] = config

--- a/ovs/lib/migration.py
+++ b/ovs/lib/migration.py
@@ -21,9 +21,9 @@ MigrationController module
 import copy
 import json
 from ovs.extensions.generic.logger import Logger
+from ovs_extensions.constants.config import CONFIG_STORE_LOCATION
 from ovs.lib.helpers.decorators import ovs_task
 from ovs.lib.helpers.toolbox import Schedule
-
 
 class MigrationController(object):
     """
@@ -474,11 +474,11 @@ class MigrationController(object):
         # Write away cluster ID to a file for back-up purposes
         try:
             cluster_id = Configuration.get(key='/ovs/framework/cluster_id', default=None)
-            with open(Configuration.CONFIG_STORE_LOCATION, 'r') as config_file:
+            with open(CONFIG_STORE_LOCATION, 'r') as config_file:
                 config = json.load(config_file)
             if cluster_id is not None and config.get('cluster_id', None) is None:
                 config['cluster_id'] = cluster_id
-                with open(Configuration.CONFIG_STORE_LOCATION, 'w') as config_file:
+                with open(CONFIG_STORE_LOCATION, 'w') as config_file:
                     json.dump(config, config_file, indent=4)
         except Exception:
             MigrationController._logger.exception('Writing cluster id to a file failed.')

--- a/ovs/lib/noderemoval.py
+++ b/ovs/lib/noderemoval.py
@@ -21,6 +21,7 @@ Module for NodeRemovalController
 import os
 import re
 import sys
+from ovs_extensions.constants.config import CACC_LOCATION, CONFIG_STORE_LOCATION
 from ovs.extensions.generic.configuration import Configuration
 from ovs.extensions.generic.logger import Logger
 from ovs_extensions.generic.interactive import Interactive
@@ -255,8 +256,8 @@ class NodeRemovalController(object):
 
             if storage_router_to_remove_online is True:
                 client = SSHClient(endpoint=storage_router_to_remove, username='root')
-                client.file_delete(filenames=[Configuration.CACC_LOCATION])
-                client.file_delete(filenames=[Configuration.CONFIG_STORE_LOCATION])
+                client.file_delete(filenames=[CACC_LOCATION])
+                client.file_delete(filenames=[CONFIG_STORE_LOCATION])
             storage_router_to_remove.delete()
             Toolbox.log(logger=NodeRemovalController._logger, messages='Successfully removed node\n')
         except Exception as exception:

--- a/ovs/lib/update.py
+++ b/ovs/lib/update.py
@@ -27,6 +27,7 @@ from ovs.dal.lists.storagerouterlist import StorageRouterList
 from ovs.dal.lists.vpoollist import VPoolList
 from ovs.dal.migration.ovsmigrator import DALMigrator
 from ovs.extensions.db.arakooninstaller import ArakoonInstaller
+from ovs_extensions.constants.config import ARAKOON_NAME
 from ovs.extensions.generic.configuration import Configuration
 from ovs_extensions.generic.filemutex import file_mutex, NoLockAvailableException
 from ovs.extensions.generic.logger import Logger
@@ -177,7 +178,7 @@ class UpdateController(object):
 
                         # For Arakoon we retrieve the clusters which have been deployed and verify whether they need a restart
                         if component == PackageFactory.COMP_FWK:
-                            cluster_names = ['ovsdb', Configuration.ARAKOON_NAME]
+                            cluster_names = ['ovsdb', ARAKOON_NAME]
                         elif component == PackageFactory.COMP_SD:
                             cluster_names = ['voldrv'] if len(VPoolList.get_vpools()) > 0 else []
                         else:
@@ -192,7 +193,7 @@ class UpdateController(object):
 
                             if package_name in pkg_component_info or arakoon_service_version is not None:
                                 arakoon_update_info = ArakoonInstaller.get_arakoon_update_info(cluster_name=actual_cluster_name,
-                                                                                               ip=StorageRouterList.get_masters()[0].ip if internal_cluster_name == Configuration.ARAKOON_NAME else None)
+                                                                                               ip=StorageRouterList.get_masters()[0].ip if internal_cluster_name == ARAKOON_NAME else None)
                                 if arakoon_update_info['internal'] is False:
                                     cls._logger.debug('StorageRouter {0}: Arakoon cluster {1} is externally managed'.format(client.ip, internal_cluster_name))
                                     continue
@@ -378,7 +379,7 @@ class UpdateController(object):
             for service_name in arakoon_services:
                 try:
                     cluster_name = ArakoonInstaller.get_cluster_name(ExtensionsToolbox.remove_prefix(service_name, 'ovs-arakoon-'))
-                    ip = System.get_my_storagerouter().ip if cluster_name == Configuration.ARAKOON_NAME else None
+                    ip = System.get_my_storagerouter().ip if cluster_name == ARAKOON_NAME else None
                     arakoon_metadata = ArakoonInstaller.get_arakoon_update_info(cluster_name=cluster_name, ip=ip)
                     if arakoon_metadata['internal'] is True:
                         arakoon_installer = ArakoonInstaller(cluster_name=cluster_name)


### PR DESCRIPTION
Change the

```
opt/<manager>/config/framework.json 
opt/<manager>/config/arakoon_cacc.ini
```
to

```
opt/OpenvStorage/config/framework.json 
opt/OpenvStorage/config/arakoon_cacc.ini
```
so that manager only nodes can properly communicate with eg. proxies.