### PR TITLE
Refresh scrubbing information for being_scrubbed property of vdisk 

### DIFF
--- a/ovs/dal/hybrids/vdisk.py
+++ b/ovs/dal/hybrids/vdisk.py
@@ -454,6 +454,7 @@ class VDisk(DataObject):
         """
         # The format was changed. 'on_going' was renamed to 'ongoing'. Account for both
         now = time.time()
-        scrub_info = self.scrubbing_information
+        reloaded_vdisk = VDisk(self.guid)
+        scrub_info = reloaded_vdisk.scrubbing_information
         # Scrubbing information shouldn't be expired
         return isinstance(scrub_info, dict) and any(scrub_info.get(key) for key in ['on_going', 'ongoing']) and self.scrubbing_information['expires'] and self.scrubbing_information['expires'] >= now


### PR DESCRIPTION
The VDisk dal hybrid property `being scrubbed` was relying on potentially old information stored in memcached.

By forcing a new VDisk object, `scrubbing information` is forced to reload and the property is certain to be provided with up-to-date information