### PR TITLE
Fixes a bug where an install would fail in following case:

### DIFF
--- a/ovs/lib/nodetype.py
+++ b/ovs/lib/nodetype.py
@@ -797,6 +797,6 @@ class NodeTypeController(object):
             for vpool_guid in Configuration.list('/ovs/vpools'):
                 for storagedriver_id in Configuration.list(HOSTS_BASE_PATH.format(vpool_guid)):
                     storagedriver_config = StorageDriverConfiguration(vpool_guid, storagedriver_id)
-                    storagedriver_config.event_publisher.events_amqp_routing_key = Configuration.get('/ovs/framework/messagequeue|queues.storagedriver')
-                    storagedriver_config.event_publisher.events_amqp_uris = uris
+                    storagedriver_config.configuration.events_config.events_amqp_routing_key = Configuration.get('/ovs/framework/messagequeue|queues.storagedriver')
+                    storagedriver_config.configuration.events_config.events_amqp_uris = uris
                     storagedriver_config.save()


### PR DESCRIPTION
Install 1 node, create backend, vpool and vdisk.
Install second node.

the StorageDriverConfiguration object was called, but the `configuration`
objects contains the config now, as this was implemented by the std_config
changes