### PR TITLE
Handle exceptions during snapshot delete

### DIFF
--- a/ovs/constants/vdisk.py
+++ b/ovs/constants/vdisk.py
@@ -23,3 +23,4 @@ LOCK_NAMESPACE = 'ovs_locks'
 
 # Scrub related
 SCRUB_VDISK_LOCK = '{0}_{{0}}'.format(LOCK_NAMESPACE)  # Second format is the vdisk guid
+SCRUB_VDISK_EXCEPTION_MESSAGE = 'VDisk is being scrubbed. Unable to remove snapshots at this time'

--- a/ovs/extensions/storageserver/tests/mockups.py
+++ b/ovs/extensions/storageserver/tests/mockups.py
@@ -84,6 +84,7 @@ class StorageRouterClient(object):
     _dtl_config_cache = {}
     _metadata_backend_config = {}
     _snapshots = {}
+    delete_snapshot_callbacks = {}
     volumes = {}
     exceptions = {}
     vrouter_id = {}
@@ -201,6 +202,9 @@ class StorageRouterClient(object):
         Delete snapshot mockup
         """
         _ = req_timeout_secs
+        callback = self.delete_snapshot_callbacks.get(volume_id, {}).get(snapshot_id)
+        if callback:
+            callback()
         del StorageRouterClient._snapshots[self.vpool_guid][volume_id][snapshot_id]
 
     def empty_info(self, req_timeout_secs=None):

--- a/ovs/lib/tests/generic_tests/test_snapshot.py
+++ b/ovs/lib/tests/generic_tests/test_snapshot.py
@@ -21,9 +21,11 @@ import os
 import time
 import datetime
 import unittest
+from ovs.constants.vdisk import SCRUB_VDISK_EXCEPTION_MESSAGE
 from ovs.dal.tests.helpers import DalHelper
 from ovs.lib.generic import GenericController
 from ovs.lib.vdisk import VDiskController
+from ovs.extensions.storageserver.tests.mockups import StorageRouterClient
 
 
 class SnapshotTestCase(unittest.TestCase):
@@ -448,6 +450,61 @@ class SnapshotTestCase(unittest.TestCase):
                                                     metadata={'label': 'ss_c_{0}:30'.format(str(h)),
                                                               'is_consistent': True,
                                                               'timestamp': str(ts)})
+
+    def test_exception_handling(self):
+        """
+        Test if the scheduled job can handle exceptions
+        """
+        def raise_an_exception(*args, **kwargs):
+            raise RuntimeError('Emulated snapshot delete error')
+
+        structure = DalHelper.build_dal_structure(
+            {'vpools': [1],
+             'vdisks': [(1, 1, 1, 1)],  # (<id>, <storagedriver_id>, <vpool_id>, <mds_service_id>)
+             'mds_services': [(1, 1)],
+             'storagerouters': [1],
+             'storagedrivers': [(1, 1, 1)]}  # (<id>, <vpool_id>, <storagerouter_id>)
+        )
+        vdisk_1 = structure['vdisks'][1]
+        [dynamic for dynamic in vdisk_1._dynamics if dynamic.name == 'snapshots'][0].timeout = 0
+
+        for i in xrange(0, 2):
+            metadata = {'label': str(i),
+                        'is_consistent': False,
+                        'is_sticky': False,
+                        'timestamp': str((int(time.time() - datetime.timedelta(2).total_seconds() - i)))}
+            snapshot_id = VDiskController.create_snapshot(vdisk_1.guid, metadata)
+            StorageRouterClient.delete_snapshot_callbacks[vdisk_1.volume_id] = {snapshot_id: raise_an_exception}
+        with self.assertRaises(RuntimeError):
+            GenericController.delete_snapshots()
+
+    def test_scrubbing_exception_handling(self):
+        """
+        Test if the scheduled job can handle exceptions
+        """
+        def raise_an_exception(*args, **kwargs):
+            raise RuntimeError(SCRUB_VDISK_EXCEPTION_MESSAGE)
+
+        structure = DalHelper.build_dal_structure(
+            {'vpools': [1],
+             'vdisks': [(1, 1, 1, 1)],  # (<id>, <storagedriver_id>, <vpool_id>, <mds_service_id>)
+             'mds_services': [(1, 1)],
+             'storagerouters': [1],
+             'storagedrivers': [(1, 1, 1)]}  # (<id>, <vpool_id>, <storagerouter_id>)
+        )
+        vdisk_1 = structure['vdisks'][1]
+        [dynamic for dynamic in vdisk_1._dynamics if dynamic.name == 'snapshots'][0].timeout = 0
+
+        for i in xrange(0, 2):
+            metadata = {'label': str(i),
+                        'is_consistent': False,
+                        'is_sticky': False,
+                        'timestamp': str((int(time.time() - datetime.timedelta(2).total_seconds() - i)))}
+            snapshot_id = VDiskController.create_snapshot(vdisk_1.guid, metadata)
+            StorageRouterClient.delete_snapshot_callbacks[vdisk_1.volume_id] = {snapshot_id: raise_an_exception}
+
+        GenericController.delete_snapshots()
+
 
     ##################
     # HELPER METHODS #

--- a/ovs/lib/tests/generic_tests/test_snapshot.py
+++ b/ovs/lib/tests/generic_tests/test_snapshot.py
@@ -37,6 +37,7 @@ class SnapshotTestCase(unittest.TestCase):
         """
         (Re)Sets the stores on every test
         """
+        StorageRouterClient.delete_snapshot_callbacks = {}
         self.volatile, self.persistent = DalHelper.setup()
 
     def tearDown(self):
@@ -460,27 +461,33 @@ class SnapshotTestCase(unittest.TestCase):
 
         structure = DalHelper.build_dal_structure(
             {'vpools': [1],
-             'vdisks': [(1, 1, 1, 1)],  # (<id>, <storagedriver_id>, <vpool_id>, <mds_service_id>)
+             'vdisks': [(1, 1, 1, 1), (2, 1, 1, 1)],  # (<id>, <storagedriver_id>, <vpool_id>, <mds_service_id>)
              'mds_services': [(1, 1)],
              'storagerouters': [1],
              'storagedrivers': [(1, 1, 1)]}  # (<id>, <vpool_id>, <storagerouter_id>)
         )
-        vdisk_1 = structure['vdisks'][1]
-        [dynamic for dynamic in vdisk_1._dynamics if dynamic.name == 'snapshots'][0].timeout = 0
 
-        for i in xrange(0, 2):
-            metadata = {'label': str(i),
-                        'is_consistent': False,
-                        'is_sticky': False,
-                        'timestamp': str((int(time.time() - datetime.timedelta(2).total_seconds() - i)))}
-            snapshot_id = VDiskController.create_snapshot(vdisk_1.guid, metadata)
-            StorageRouterClient.delete_snapshot_callbacks[vdisk_1.volume_id] = {snapshot_id: raise_an_exception}
+        vdisk_1, vdisk_2 = structure['vdisks'].values()
+        vdisks = [vdisk_1, vdisk_2]
+
+        for vdisk in vdisks:
+            [dynamic for dynamic in vdisk._dynamics if dynamic.name == 'snapshots'][0].timeout = 0
+            for i in xrange(0, 2):
+                metadata = {'label': str(i),
+                            'is_consistent': False,
+                            'is_sticky': False,
+                            'timestamp': str((int(time.time() - datetime.timedelta(2).total_seconds() - i)))}
+                snapshot_id = VDiskController.create_snapshot(vdisk.guid, metadata)
+                if vdisk == vdisk_1:
+                    StorageRouterClient.delete_snapshot_callbacks[vdisk.volume_id] = {snapshot_id: raise_an_exception}
         with self.assertRaises(RuntimeError):
             GenericController.delete_snapshots()
+        self.assertEqual(1, len(vdisk_2.snapshot_ids), 'One snapshot should be removed for vdisk 2')
+        self.assertEqual(2, len(vdisk_1.snapshot_ids), 'No snapshots should be removed for vdisk 1')
 
     def test_scrubbing_exception_handling(self):
         """
-        Test if the scheduled job can handle exceptions
+        Test if the scheduled job can handle scrub related exceptions
         """
         def raise_an_exception(*args, **kwargs):
             raise RuntimeError(SCRUB_VDISK_EXCEPTION_MESSAGE)
@@ -504,7 +511,6 @@ class SnapshotTestCase(unittest.TestCase):
             StorageRouterClient.delete_snapshot_callbacks[vdisk_1.volume_id] = {snapshot_id: raise_an_exception}
 
         GenericController.delete_snapshots()
-
 
     ##################
     # HELPER METHODS #

--- a/ovs/lib/vdisk.py
+++ b/ovs/lib/vdisk.py
@@ -25,6 +25,7 @@ import time
 import uuid
 import pickle
 import random
+from ovs.constants.vdisk import SCRUB_VDISK_EXCEPTION_MESSAGE
 from ovs.dal.exceptions import ObjectNotFoundException
 from ovs.dal.hybrids.domain import Domain
 from ovs.dal.hybrids.j_vdiskdomain import VDiskDomain
@@ -566,7 +567,7 @@ class VDiskController(object):
                     results[vdisk_guid] = [False, ex.message]
                 continue
             if vdisk.being_scrubbed:
-                msg = 'VDisk is being scrubbed. Unable to remove snapshots at this time'
+                msg = SCRUB_VDISK_EXCEPTION_MESSAGE
                 results[vdisk_guid].update({'success': False,
                                             'error': msg})
                 if backwards_compat is True:


### PR DESCRIPTION
Will resolve #2292 

Testing older revisions fails on Travis. Unittest results:
```
############
# OVERVIEW #
############

  - TestModule: /opt/OpenvStorage/ovs/dal/tests/test_alba  (2 tests)
    - DURATION: < 1 second
    - SUCCESS: 2

  - TestModule: /opt/OpenvStorage/ovs/dal/tests/test_basic  (69 tests)
    - DURATION: 2 seconds
    - SUCCESS: 69

  - TestModule: /opt/OpenvStorage/ovs/dal/tests/test_hybrids  (1 test)
    - DURATION: < 1 second
    - SUCCESS: 1

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/alba_tests/test_lib_alba  (1 test)
    - DURATION: 5 seconds
    - SUCCESS: 1

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/alba_tests/test_nsmcheckup  (1 test)
    - DURATION: 7 seconds
    - SUCCESS: 1

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/generic_tests/test_generic  (2 tests)
    - DURATION: 3 seconds
    - SUCCESS: 2

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/generic_tests/test_scrubbing  (12 tests)
    - DURATION: 33 seconds
    - SUCCESS: 12

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/generic_tests/test_snapshot  (14 tests)
    - DURATION: 14 seconds
    - SUCCESS: 14

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/helpers_tests/test_helpers  (12 tests)
    - DURATION: 2 seconds
    - SUCCESS: 12

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/mdsservice_tests/test_mdscatchup  (7 tests)
    - DURATION: 12 seconds
    - SUCCESS: 7

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/mdsservice_tests/test_mdsservice  (9 tests)
    - DURATION: 59 seconds
    - SUCCESS: 9

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/storagedriver_tests/test_controller  (1 test)
    - DURATION: < 1 second
    - SUCCESS: 1

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/storagedriver_tests/test_node_configs  (2 tests)
    - DURATION: < 1 second
    - SUCCESS: 2

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/vdisk_tests/test_dtl_checkup  (10 tests)
    - DURATION: 16 seconds
    - SUCCESS: 10

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/vdisk_tests/test_events  (3 tests)
    - DURATION: 2 seconds
    - SUCCESS: 3

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/vdisk_tests/test_get_set_config_params  (5 tests)
    - DURATION: 2 seconds
    - SUCCESS: 5

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/vdisk_tests/test_snapshot  (4 tests)
    - DURATION: 2 seconds
    - SUCCESS: 4

  - TestModule: /opt/OpenvStorage/ovs/lib/tests/vdisk_tests/test_vdisk  (10 tests)
    - DURATION: 8 seconds
    - SUCCESS: 10

  - TestModule: /opt/OpenvStorage/webapps/api/tests/test_api_configuration  (2 tests)
    - DURATION: < 1 second
    - SUCCESS: 2

  - TestModule: /opt/OpenvStorage/webapps/api/tests/test_authentication  (8 tests)
    - DURATION: < 1 second
    - SUCCESS: 8

  - TestModule: /opt/OpenvStorage/webapps/api/tests/test_decorators  (6 tests)
    - DURATION: < 1 second
    - SUCCESS: 6


###########
# SUMMARY #
###########

  - Total amount of tests: 181
  - Total duration: 2 minutes and 48 seconds
    - SUCCESS: 181 / 181 (100.00 %)

root@DEV-3N-199-181:~# date
Thu May  2 10:30:57 CEST 2019
```